### PR TITLE
Add integration tests

### DIFF
--- a/.github/actions/docker-install-macos/action.yml
+++ b/.github/actions/docker-install-macos/action.yml
@@ -1,0 +1,17 @@
+---
+name: "Install Docker on macOS"
+description: "Performs an unattended install of Docker Desktop for MacOS"
+runs:
+  using: "composite"
+  steps:
+    # From https://github.com/docker/for-mac/issues/2359#issuecomment-943131345
+    - run: |
+        brew install --cask docker
+        sudo /Applications/Docker.app/Contents/MacOS/Docker --unattended --install-privileged-components
+        open -a /Applications/Docker.app --args --unattended --accept-license
+        while ! /Applications/Docker.app/Contents/Resources/bin/docker info &>/dev/null; do sleep 1; done
+      shell: bash
+branding:
+  icon: "tag"
+  color: "blue"
+...

--- a/.github/check.go
+++ b/.github/check.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+)
+
+func main() {
+	resp, err := http.Get("https://registry-1.docker.io/v2/")
+	fmt.Printf("Error: %v\n", err)
+	if err == nil {
+		dr, _ := httputil.DumpResponse(resp, true)
+		fmt.Printf("Body:\n===\n%s\n===\n", string(dr))
+	}
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,13 @@ jobs:
           distribution: 'zulu'
           java-version: ${{ matrix.java }}
           cache: 'gradle'
+      - name: Install Docker on macOS
+        if: matrix.os == 'macos-latest'
+        uses: ./.github/actions/docker-install-macos
+      - name: docker version
+        run: docker version
+      - name: docker info
+        run: docker info
       - name: clean build
         run: ./gradlew clean build --info --stacktrace
       - name: Publish Test Report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,19 @@ jobs:
         run: docker version
       - name: docker info
         run: docker info
+      - name: Set up Go
+        if: matrix.os == 'windows-latest'
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+      - name: debug dns issues on Windows
+        if: matrix.os == 'windows-latest'
+        run: |
+          nslookup registry-1.docker.io
+          curl -v https://registry-1.docker.io/
+          curl -v https://registry-1.docker.io/v2/
+          curl -v --head https://registry-1.docker.io/v2/gesellix/echo-server/manifests/os-windows
+          go run .github/check.go
       - name: clean build
         run: ./gradlew clean build --info --stacktrace
       - name: Publish Test Report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,17 @@ jobs:
       - name: Install Docker on macOS
         if: matrix.os == 'macos-latest'
         uses: ./.github/actions/docker-install-macos
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: docker version
         run: docker version
       - name: docker info
         run: docker info
+      - name: java version
+        run: java -version
       - name: Set up Go
         if: matrix.os == 'windows-latest'
         uses: actions/setup-go@v2

--- a/api-client/build.gradle.kts
+++ b/api-client/build.gradle.kts
@@ -12,8 +12,6 @@ plugins {
   id("io.freefair.maven-central.validate-poms")
 }
 
-val remoteApiVersion = "1.41"
-
 java {
   sourceCompatibility = JavaVersion.VERSION_1_8
   targetCompatibility = JavaVersion.VERSION_1_8
@@ -26,13 +24,22 @@ dependencies {
   kapt("com.squareup.moshi:moshi-kotlin-codegen:1.12.0")
   implementation("com.squareup.okhttp3:okhttp:[4.9,5)!!4.9.2")
 //  implementation("com.squareup.okhttp3:logging-interceptor:[4.9,5)!!4.9.2")
-  testImplementation("io.kotlintest:kotlintest-runner-junit5:3.4.2")
-  implementation("de.gesellix:docker-remote-api-model-${remoteApiVersion.replace(".", "-")}:2021-10-04T21-50-00")
+  implementation("de.gesellix:docker-remote-api-model-1-41:2021-10-16T19-28-00")
   implementation("de.gesellix:docker-engine:2021-10-09T19-06-00")
   implementation("de.gesellix:docker-filesocket:2021-09-20T20-10-00")
 
   implementation("org.slf4j:slf4j-api:[1.7,)!!1.7.32")
   testImplementation("ch.qos.logback:logback-classic:[1.2,2)!!1.2.6")
+
+  testImplementation("io.kotlintest:kotlintest-runner-junit5:3.4.2")
+  testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.1")
+  testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.1")
+  testRuntimeOnly("cglib:cglib-nodep:3.3.0")
+  testImplementation("org.junit.platform:junit-platform-launcher:1.8.0")
+  testImplementation("org.junit.platform:junit-platform-commons:1.8.0")
+
+  testImplementation("org.apache.commons:commons-compress:1.21")
+  testImplementation("de.gesellix:testutil:[2021-08-05T22-09-32,)")
 }
 
 tasks.withType(Test::class.java) {
@@ -76,7 +83,7 @@ publishing {
     register(publicationName, MavenPublication::class) {
       pom {
         name.set("docker-remote-api-client")
-        description.set("Client for the Docker remote api v${remoteApiVersion}")
+        description.set("Client for the Docker remote api")
         url.set("https://github.com/docker-client/docker-remote-api-client")
         licenses {
           license {

--- a/api-client/src/main/java/de/gesellix/docker/remote/api/EngineApiClient.java
+++ b/api-client/src/main/java/de/gesellix/docker/remote/api/EngineApiClient.java
@@ -1,0 +1,47 @@
+package de.gesellix.docker.remote.api;
+
+import de.gesellix.docker.remote.api.client.ConfigApi;
+import de.gesellix.docker.remote.api.client.ContainerApi;
+import de.gesellix.docker.remote.api.client.DistributionApi;
+import de.gesellix.docker.remote.api.client.ExecApi;
+import de.gesellix.docker.remote.api.client.ImageApi;
+import de.gesellix.docker.remote.api.client.NetworkApi;
+import de.gesellix.docker.remote.api.client.NodeApi;
+import de.gesellix.docker.remote.api.client.PluginApi;
+import de.gesellix.docker.remote.api.client.SecretApi;
+import de.gesellix.docker.remote.api.client.ServiceApi;
+import de.gesellix.docker.remote.api.client.SwarmApi;
+import de.gesellix.docker.remote.api.client.SystemApi;
+import de.gesellix.docker.remote.api.client.TaskApi;
+import de.gesellix.docker.remote.api.client.VolumeApi;
+
+public interface EngineApiClient {
+
+  ConfigApi getConfigApi();
+
+  ContainerApi getContainerApi();
+
+  DistributionApi getDistributionApi();
+
+  ExecApi getExecApi();
+
+  ImageApi getImageApi();
+
+  NetworkApi getNetworkApi();
+
+  NodeApi getNodeApi();
+
+  PluginApi getPluginApi();
+
+  SecretApi getSecretApi();
+
+  ServiceApi getServiceApi();
+
+  SwarmApi getSwarmApi();
+
+  SystemApi getSystemApi();
+
+  TaskApi getTaskApi();
+
+  VolumeApi getVolumeApi();
+}

--- a/api-client/src/main/java/de/gesellix/docker/remote/api/EngineApiClientImpl.java
+++ b/api-client/src/main/java/de/gesellix/docker/remote/api/EngineApiClientImpl.java
@@ -1,0 +1,121 @@
+package de.gesellix.docker.remote.api;
+
+import de.gesellix.docker.remote.api.client.ConfigApi;
+import de.gesellix.docker.remote.api.client.ContainerApi;
+import de.gesellix.docker.remote.api.client.DistributionApi;
+import de.gesellix.docker.remote.api.client.ExecApi;
+import de.gesellix.docker.remote.api.client.ImageApi;
+import de.gesellix.docker.remote.api.client.NetworkApi;
+import de.gesellix.docker.remote.api.client.NodeApi;
+import de.gesellix.docker.remote.api.client.PluginApi;
+import de.gesellix.docker.remote.api.client.SecretApi;
+import de.gesellix.docker.remote.api.client.ServiceApi;
+import de.gesellix.docker.remote.api.client.SwarmApi;
+import de.gesellix.docker.remote.api.client.SystemApi;
+import de.gesellix.docker.remote.api.client.TaskApi;
+import de.gesellix.docker.remote.api.client.VolumeApi;
+
+public class EngineApiClientImpl implements EngineApiClient {
+
+  private final ConfigApi configApi;
+  private final ContainerApi containerApi;
+  private final DistributionApi distributionApi;
+  private final ExecApi execApi;
+  private final ImageApi imageApi;
+  private final NetworkApi networkApi;
+  private final NodeApi nodeApi;
+  private final PluginApi pluginApi;
+  private final SecretApi secretApi;
+  private final ServiceApi serviceApi;
+  private final SwarmApi swarmApi;
+  private final SystemApi systemApi;
+  private final TaskApi taskApi;
+  private final VolumeApi volumeApi;
+
+  public EngineApiClientImpl() {
+    configApi = new ConfigApi();
+    containerApi = new ContainerApi();
+    distributionApi = new DistributionApi();
+    execApi = new ExecApi();
+    imageApi = new ImageApi();
+    networkApi = new NetworkApi();
+    nodeApi = new NodeApi();
+    pluginApi = new PluginApi();
+    secretApi = new SecretApi();
+    serviceApi = new ServiceApi();
+    swarmApi = new SwarmApi();
+    systemApi = new SystemApi();
+    taskApi = new TaskApi();
+    volumeApi = new VolumeApi();
+  }
+
+  @Override
+  public ConfigApi getConfigApi() {
+    return configApi;
+  }
+
+  @Override
+  public ContainerApi getContainerApi() {
+    return containerApi;
+  }
+
+  @Override
+  public DistributionApi getDistributionApi() {
+    return distributionApi;
+  }
+
+  @Override
+  public ExecApi getExecApi() {
+    return execApi;
+  }
+
+  @Override
+  public ImageApi getImageApi() {
+    return imageApi;
+  }
+
+  @Override
+  public NetworkApi getNetworkApi() {
+    return networkApi;
+  }
+
+  @Override
+  public NodeApi getNodeApi() {
+    return nodeApi;
+  }
+
+  @Override
+  public PluginApi getPluginApi() {
+    return pluginApi;
+  }
+
+  @Override
+  public SecretApi getSecretApi() {
+    return secretApi;
+  }
+
+  @Override
+  public ServiceApi getServiceApi() {
+    return serviceApi;
+  }
+
+  @Override
+  public SwarmApi getSwarmApi() {
+    return swarmApi;
+  }
+
+  @Override
+  public SystemApi getSystemApi() {
+    return systemApi;
+  }
+
+  @Override
+  public TaskApi getTaskApi() {
+    return taskApi;
+  }
+
+  @Override
+  public VolumeApi getVolumeApi() {
+    return volumeApi;
+  }
+}

--- a/api-client/src/test/java/de/gesellix/docker/remote/api/client/ConfigApiIntegrationTest.java
+++ b/api-client/src/test/java/de/gesellix/docker/remote/api/client/ConfigApiIntegrationTest.java
@@ -1,0 +1,86 @@
+package de.gesellix.docker.remote.api.client;
+
+import de.gesellix.docker.remote.api.Config;
+import de.gesellix.docker.remote.api.ConfigSpec;
+import de.gesellix.docker.remote.api.EngineApiClient;
+import de.gesellix.docker.remote.api.IdResponse;
+import de.gesellix.docker.remote.api.LocalNodeState;
+import de.gesellix.docker.remote.api.testutil.DockerEngineAvailable;
+import de.gesellix.docker.remote.api.testutil.InjectDockerClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DockerEngineAvailable(requiredSwarmMode = LocalNodeState.Active)
+class ConfigApiIntegrationTest {
+
+  @InjectDockerClient
+  private EngineApiClient engineApiClient;
+
+  ConfigApi configApi;
+
+  IdResponse defaultConfig;
+
+  @BeforeEach
+  public void setup() {
+    configApi = engineApiClient.getConfigApi();
+
+    String encoded = Base64.getEncoder().encodeToString("config-data".getBytes());
+    defaultConfig = configApi.configCreate(new ConfigSpec("config-name", Collections.emptyMap(), encoded, null));
+  }
+
+  @AfterEach
+  public void cleanup() {
+    configApi.configDelete(defaultConfig.getId());
+  }
+
+  @Test
+  public void configCreate() {
+    String encoded = Base64.getEncoder().encodeToString("config-data".getBytes());
+    IdResponse response = configApi.configCreate(new ConfigSpec("my-config", Collections.emptyMap(), encoded, null));
+    assertTrue(response.getId().matches("\\w{5,}"));
+
+    configApi.configDelete(response.getId());
+  }
+
+  @Test
+  public void configDelete() {
+    String encoded = Base64.getEncoder().encodeToString("config-data".getBytes());
+    IdResponse response = configApi.configCreate(new ConfigSpec("my-config", Collections.emptyMap(), encoded, null));
+
+    assertDoesNotThrow(() -> configApi.configDelete(response.getId()));
+  }
+
+  @Test
+  public void configInspect() {
+    Config inspect = configApi.configInspect(defaultConfig.getId());
+    assertEquals("config-name", inspect.getSpec().getName());
+    assertEquals("config-data", new String(Base64.getDecoder().decode(inspect.getSpec().getData())));
+  }
+
+  @Test
+  public void configList() {
+    List<Config> configs = configApi.configList(null);
+    Stream<Config> filtered = configs.stream().filter(c -> Objects.equals(c.getID(), defaultConfig.getId()));
+    assertEquals(defaultConfig.getId(), filtered.findFirst().orElse(new Config()).getID());
+  }
+
+  @Test
+  public void configUpdate() {
+    Config inspect = configApi.configInspect(defaultConfig.getId());
+    ConfigSpec configSpec = inspect.getSpec();
+    assertNotNull(configSpec);
+    assertDoesNotThrow(() -> configApi.configUpdate(defaultConfig.getId(), inspect.getVersion().getIndex(), new ConfigSpec(configSpec.getName(), Collections.singletonMap("foo", "bar"), configSpec.getData(), configSpec.getTemplating())));
+  }
+}

--- a/api-client/src/test/java/de/gesellix/docker/remote/api/client/ContainerApiIntegrationTest.java
+++ b/api-client/src/test/java/de/gesellix/docker/remote/api/client/ContainerApiIntegrationTest.java
@@ -16,6 +16,7 @@ import de.gesellix.docker.remote.api.core.Frame;
 import de.gesellix.docker.remote.api.core.LoggingExtensionsKt;
 import de.gesellix.docker.remote.api.core.StreamCallback;
 import de.gesellix.docker.remote.api.testutil.DisabledIfDaemonOnWindowsOs;
+import de.gesellix.docker.remote.api.testutil.DisabledIfNotPausable;
 import de.gesellix.docker.remote.api.testutil.DockerEngineAvailable;
 import de.gesellix.docker.remote.api.testutil.Failsafe;
 import de.gesellix.docker.remote.api.testutil.InjectDockerClient;
@@ -470,6 +471,7 @@ class ContainerApiIntegrationTest {
     removeContainer(engineApiClient, "container-kill-test");
   }
 
+  @DisabledIfNotPausable
   @Test
   public void containerPauseUnpause() {
     imageApi.imageCreate(testImage.getImageName(), null, null, testImage.getImageTag(), null, null, null, null, null);

--- a/api-client/src/test/java/de/gesellix/docker/remote/api/client/ContainerApiIntegrationTest.java
+++ b/api-client/src/test/java/de/gesellix/docker/remote/api/client/ContainerApiIntegrationTest.java
@@ -1,0 +1,750 @@
+package de.gesellix.docker.remote.api.client;
+
+import com.squareup.moshi.Moshi;
+import de.gesellix.docker.remote.api.ContainerCreateRequest;
+import de.gesellix.docker.remote.api.ContainerCreateResponse;
+import de.gesellix.docker.remote.api.ContainerInspectResponse;
+import de.gesellix.docker.remote.api.ContainerPruneResponse;
+import de.gesellix.docker.remote.api.ContainerTopResponse;
+import de.gesellix.docker.remote.api.ContainerUpdateRequest;
+import de.gesellix.docker.remote.api.ContainerUpdateResponse;
+import de.gesellix.docker.remote.api.EngineApiClient;
+import de.gesellix.docker.remote.api.RestartPolicy;
+import de.gesellix.docker.remote.api.core.Cancellable;
+import de.gesellix.docker.remote.api.core.ClientException;
+import de.gesellix.docker.remote.api.core.Frame;
+import de.gesellix.docker.remote.api.core.LoggingExtensionsKt;
+import de.gesellix.docker.remote.api.core.StreamCallback;
+import de.gesellix.docker.remote.api.testutil.DisabledIfDaemonOnWindowsOs;
+import de.gesellix.docker.remote.api.testutil.DockerEngineAvailable;
+import de.gesellix.docker.remote.api.testutil.Failsafe;
+import de.gesellix.docker.remote.api.testutil.InjectDockerClient;
+import de.gesellix.docker.remote.api.testutil.TestImage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.stream.Collectors;
+
+import static de.gesellix.docker.remote.api.testutil.Constants.LABEL_KEY;
+import static de.gesellix.docker.remote.api.testutil.Constants.LABEL_VALUE;
+import static de.gesellix.docker.remote.api.testutil.Failsafe.removeContainer;
+import static java.time.temporal.ChronoUnit.SECONDS;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DockerEngineAvailable
+class ContainerApiIntegrationTest {
+
+  private static final Logger log = LoggingExtensionsKt.logger(ContainerApiIntegrationTest.class.getName()).getValue();
+
+  @InjectDockerClient
+  private EngineApiClient engineApiClient;
+
+  private TestImage testImage;
+
+  ContainerApi containerApi;
+  ImageApi imageApi;
+
+  @BeforeEach
+  public void setup() {
+    containerApi = engineApiClient.getContainerApi();
+    imageApi = engineApiClient.getImageApi();
+    testImage = new TestImage(engineApiClient);
+  }
+
+  @Test
+  public void containerList() {
+    List<Map<String, Object>> containers = containerApi.containerList(null, null, null, null);
+    assertNotNull(containers);
+  }
+
+  @Test
+  public void containerCreate() {
+    imageApi.imageCreate(testImage.getImageName(), null, null, testImage.getImageTag(), null, null, null, null, null);
+
+    ContainerCreateRequest containerCreateRequest = new ContainerCreateRequest(
+        null, null, null,
+        false, false, false,
+        null,
+        false, null, null,
+        null,
+        singletonList("-"),
+        null,
+        null,
+        testImage.getImageWithTag(),
+        null, null, null,
+        null, null,
+        null,
+        singletonMap(LABEL_KEY, LABEL_VALUE),
+        null, null,
+        null,
+        null,
+        null
+    );
+    ContainerCreateResponse container = containerApi.containerCreate(containerCreateRequest, "container-create-test");
+    assertTrue(container.getId().matches("\\w+"));
+
+    removeContainer(engineApiClient, "container-create-test");
+  }
+
+  @Test
+  public void containerDelete() {
+    imageApi.imageCreate(testImage.getImageName(), null, null, testImage.getImageTag(), null, null, null, null, null);
+
+    ContainerCreateRequest containerCreateRequest = new ContainerCreateRequest(
+        null, null, null,
+        false, false, false,
+        null,
+        false, null, null,
+        null,
+        singletonList("-"),
+        null,
+        null,
+        testImage.getImageWithTag(),
+        null, null, null,
+        null, null,
+        null,
+        singletonMap(LABEL_KEY, LABEL_VALUE),
+        null, null,
+        null,
+        null,
+        null
+    );
+    containerApi.containerCreate(containerCreateRequest, "container-delete-test");
+    assertDoesNotThrow(() -> containerApi.containerDelete("container-delete-test", null, null, null));
+    assertDoesNotThrow(() -> containerApi.containerDelete("container-delete-missing", null, null, null));
+
+    Failsafe.perform(() -> imageApi.imageDelete(testImage.getImageWithTag(), null, null));
+  }
+
+  // WCOW does not support exporting containers
+  // See https://github.com/moby/moby/issues/33581
+  @DisabledIfDaemonOnWindowsOs
+  @Test
+  public void containerExport() {
+    ContainerCreateRequest containerCreateRequest = new ContainerCreateRequest(
+        null, null, null,
+        false, false, false,
+        null,
+        false, null, null,
+        null,
+        null,
+        null,
+        null,
+        testImage.getImageWithTag(),
+        null, null, null,
+        null, null,
+        null,
+        singletonMap(LABEL_KEY, LABEL_VALUE),
+        null, null,
+        null,
+        null,
+        null
+    );
+    containerApi.containerCreate(containerCreateRequest, "container-export");
+    assertDoesNotThrow(() -> containerApi.containerExport("container-export"));
+    removeContainer(engineApiClient, "container-export");
+  }
+
+  @Test
+  public void containerInspect() {
+    imageApi.imageCreate(testImage.getImageName(), null, null, testImage.getImageTag(), null, null, null, null, null);
+
+    ContainerCreateRequest containerCreateRequest = new ContainerCreateRequest(
+        null, null, null,
+        false, false, false,
+        null,
+        false, null, null,
+        null,
+        singletonList("-"),
+        null,
+        null,
+        testImage.getImageWithTag(),
+        null, null, null,
+        null, null,
+        null,
+        singletonMap(LABEL_KEY, LABEL_VALUE),
+        null, null,
+        null,
+        null,
+        null
+    );
+    containerApi.containerCreate(containerCreateRequest, "container-inspect-test");
+    ContainerInspectResponse container = containerApi.containerInspect("container-inspect-test", false);
+    assertEquals("/container-inspect-test", container.getName());
+
+    removeContainer(engineApiClient, "container-inspect-test");
+  }
+
+  @Test
+  public void containerInspectMissing() {
+    ClientException clientException = assertThrows(ClientException.class, () -> containerApi.containerInspect("random-" + UUID.randomUUID(), false));
+    assertEquals(404, clientException.getStatusCode());
+  }
+
+  @Test
+  public void containerRename() {
+    imageApi.imageCreate(testImage.getImageName(), null, null, testImage.getImageTag(), null, null, null, null, null);
+
+    ContainerCreateRequest containerCreateRequest = new ContainerCreateRequest(
+        null, null, null,
+        false, false, false,
+        null,
+        false, null, null,
+        null,
+        singletonList("-"),
+        null,
+        null,
+        testImage.getImageWithTag(),
+        null, null, null,
+        null, null,
+        null,
+        singletonMap(LABEL_KEY, LABEL_VALUE),
+        null, null,
+        null,
+        null,
+        null
+    );
+    containerApi.containerCreate(containerCreateRequest, "container-rename-test");
+    assertDoesNotThrow(() -> containerApi.containerRename("container-rename-test", "fancy-name"));
+
+    removeContainer(engineApiClient, "fancy-name");
+  }
+
+  @Test
+  public void containerStartStopWait() {
+    imageApi.imageCreate(testImage.getImageName(), null, null, testImage.getImageTag(), null, null, null, null, null);
+
+    ContainerCreateRequest containerCreateRequest = new ContainerCreateRequest(
+        null, null, null,
+        false, false, false,
+        null,
+        false, null, null,
+        null,
+        null,
+        null,
+        null,
+        testImage.getImageWithTag(),
+        null, null, null,
+        null, null,
+        null,
+        singletonMap(LABEL_KEY, LABEL_VALUE),
+        null, null,
+        null,
+        null,
+        null
+    );
+    containerApi.containerCreate(containerCreateRequest, "container-start-test");
+    containerApi.containerStart("container-start-test", null);
+    ContainerInspectResponse container = containerApi.containerInspect("container-start-test", false);
+    assertTrue(container.getState().getRunning());
+
+    removeContainer(engineApiClient, "container-start-test");
+  }
+
+  @Test
+  public void containerLogsWithoutTty() {
+    imageApi.imageCreate(testImage.getImageName(), null, null, testImage.getImageTag(), null, null, null, null, null);
+
+    ContainerCreateRequest containerCreateRequest = new ContainerCreateRequest(
+        null, null, null,
+        false, false, false,
+        null,
+        false, null, null,
+        null,
+        null,
+        null,
+        null,
+        testImage.getImageWithTag(),
+        null, null, null,
+        null, null,
+        null,
+        singletonMap(LABEL_KEY, LABEL_VALUE),
+        null, null,
+        null,
+        null,
+        null
+    );
+    containerApi.containerCreate(containerCreateRequest, "container-logs-test");
+    containerApi.containerStart("container-logs-test", null);
+
+    Duration timeout = Duration.of(5, SECONDS);
+    LogFrameStreamCallback callback = new LogFrameStreamCallback();
+
+    new Thread(() -> containerApi.containerLogs(
+        "container-logs-test",
+        false, true, true, null, null, null, null,
+        callback, timeout.toMillis())).start();
+
+    CountDownLatch wait = new CountDownLatch(1);
+    new Timer().schedule(new TimerTask() {
+      @Override
+      public void run() {
+        callback.job.cancel();
+        wait.countDown();
+      }
+    }, 5000);
+
+    try {
+      wait.await();
+    }
+    catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+    Optional<Frame> frame = callback.frames.stream().findAny();
+    assertTrue(frame.isPresent());
+    assertSame(frame.get().getStreamType(), Frame.StreamType.STDOUT);
+
+    removeContainer(engineApiClient, "container-logs-test");
+  }
+
+  @Test
+  public void containerLogsWithTty() {
+    imageApi.imageCreate(testImage.getImageName(), null, null, testImage.getImageTag(), null, null, null, null, null);
+
+    ContainerCreateRequest containerCreateRequest = new ContainerCreateRequest(
+        null, null, null,
+        false, false, false,
+        null,
+        true, null, null,
+        null,
+        null,
+        null,
+        null,
+        testImage.getImageWithTag(),
+        null, null, null,
+        null, null,
+        null,
+        singletonMap(LABEL_KEY, LABEL_VALUE),
+        null, null,
+        null,
+        null,
+        null
+    );
+    containerApi.containerCreate(containerCreateRequest, "container-logs-with-tty-test");
+    containerApi.containerStart("container-logs-with-tty-test", null);
+
+    Duration timeout = Duration.of(5, SECONDS);
+    LogFrameStreamCallback callback = new LogFrameStreamCallback();
+
+    new Thread(() -> containerApi.containerLogs(
+        "container-logs-with-tty-test",
+        false, true, true, null, null, null, null,
+        callback, timeout.toMillis())).start();
+
+    CountDownLatch wait = new CountDownLatch(1);
+    new Timer().schedule(new TimerTask() {
+      @Override
+      public void run() {
+        callback.job.cancel();
+        wait.countDown();
+      }
+    }, 5000);
+
+    try {
+      wait.await();
+    }
+    catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+    assertSame(callback.frames.stream().findAny().get().getStreamType(), Frame.StreamType.RAW);
+
+    removeContainer(engineApiClient, "container-logs-with-tty-test");
+  }
+
+  @Test
+  public void containerUpdate() {
+    imageApi.imageCreate(testImage.getImageName(), null, null, testImage.getImageTag(), null, null, null, null, null);
+
+    ContainerCreateRequest containerCreateRequest = new ContainerCreateRequest(
+        null, null, null,
+        false, false, false,
+        null,
+        false, null, null,
+        null,
+        null,
+        null,
+        null,
+        testImage.getImageWithTag(),
+        null, null, null,
+        null, null,
+        null,
+        singletonMap(LABEL_KEY, LABEL_VALUE),
+        null, null,
+        null,
+        null,
+        null
+    );
+    containerApi.containerCreate(containerCreateRequest, "container-update-test");
+    containerApi.containerStart("container-update-test", null);
+    ContainerUpdateRequest updateRequest = new ContainerUpdateRequest(
+        null, null, null,
+        null, null, null, null, null, null,
+        null, null, null, null, null, null,
+        null, null, null,
+        null, null, null, null, null,
+        null, null, null, null, null,
+        null, null, null, null,
+        new RestartPolicy(RestartPolicy.Name.UnlessMinusStopped, null));
+    ContainerUpdateResponse updateResponse = containerApi.containerUpdate("container-update-test", updateRequest);
+    assertTrue(updateResponse.getWarnings() == null || updateResponse.getWarnings().isEmpty());
+
+    removeContainer(engineApiClient, "container-update-test");
+  }
+
+  @Test
+  public void containerRestart() {
+    imageApi.imageCreate(testImage.getImageName(), null, null, testImage.getImageTag(), null, null, null, null, null);
+
+    ContainerCreateRequest containerCreateRequest = new ContainerCreateRequest(
+        null, null, null,
+        false, false, false,
+        null,
+        false, null, null,
+        null,
+        null,
+        null,
+        null,
+        testImage.getImageWithTag(),
+        null, null, null,
+        null, null,
+        null,
+        singletonMap(LABEL_KEY, LABEL_VALUE),
+        null, null,
+        null,
+        null,
+        null
+    );
+    containerApi.containerCreate(containerCreateRequest, "container-restart-test");
+    containerApi.containerStart("container-restart-test", null);
+    assertDoesNotThrow(() -> containerApi.containerRestart("container-restart-test", 5));
+
+    removeContainer(engineApiClient, "container-restart-test");
+  }
+
+  @Test
+  public void containerKill() {
+    imageApi.imageCreate(testImage.getImageName(), null, null, testImage.getImageTag(), null, null, null, null, null);
+
+    ContainerCreateRequest containerCreateRequest = new ContainerCreateRequest(
+        null, null, null,
+        false, false, false,
+        null,
+        false, null, null,
+        null,
+        null,
+        null,
+        null,
+        testImage.getImageWithTag(),
+        null, null, null,
+        null, null,
+        null,
+        singletonMap(LABEL_KEY, LABEL_VALUE),
+        null, null,
+        null,
+        null,
+        null
+    );
+    containerApi.containerCreate(containerCreateRequest, "container-kill-test");
+    containerApi.containerStart("container-kill-test", null);
+    assertDoesNotThrow(() -> containerApi.containerKill("container-kill-test", null));
+
+    removeContainer(engineApiClient, "container-kill-test");
+  }
+
+  @Test
+  public void containerPauseUnpause() {
+    imageApi.imageCreate(testImage.getImageName(), null, null, testImage.getImageTag(), null, null, null, null, null);
+
+    ContainerCreateRequest containerCreateRequest = new ContainerCreateRequest(
+        null, null, null,
+        false, false, false,
+        null,
+        false, null, null,
+        null,
+        null,
+        null,
+        null,
+        testImage.getImageWithTag(),
+        null, null, null,
+        null, null,
+        null,
+        singletonMap(LABEL_KEY, LABEL_VALUE),
+        null, null,
+        null,
+        null,
+        null
+    );
+    containerApi.containerCreate(containerCreateRequest, "container-pause-test");
+    containerApi.containerStart("container-pause-test", null);
+    assertDoesNotThrow(() -> containerApi.containerPause("container-pause-test"));
+    ContainerInspectResponse pausedContainer = containerApi.containerInspect("container-pause-test", false);
+    assertTrue(pausedContainer.getState().getPaused());
+    assertDoesNotThrow(() -> containerApi.containerUnpause("container-pause-test"));
+    ContainerInspectResponse unpausedContainer = containerApi.containerInspect("container-pause-test", false);
+    assertFalse(unpausedContainer.getState().getPaused());
+
+    removeContainer(engineApiClient, "container-pause-test");
+  }
+
+  @Test
+  public void containerPrune() {
+    imageApi.imageCreate(testImage.getImageName(), null, null, testImage.getImageTag(), null, null, null, null, null);
+
+    ContainerCreateRequest containerCreateRequest = new ContainerCreateRequest(
+        null, null, null,
+        false, false, false,
+        null,
+        false, null, null,
+        null,
+        null,
+        null,
+        null,
+        testImage.getImageWithTag(),
+        null, null, null,
+        null, null,
+        null,
+        singletonMap(LABEL_KEY, LABEL_VALUE),
+        null, null,
+        null,
+        null,
+        null
+    );
+    containerApi.containerCreate(containerCreateRequest, "container-prune-test");
+
+    Map<String, List<String>> filter = new HashMap<>();
+    filter.put("label", singletonList(LABEL_KEY));
+    String filterJson = new Moshi.Builder().build().adapter(Map.class).toJson(filter);
+
+    Optional<Map<String, Object>> toBePruned = containerApi.containerList(true, null, null, filterJson).stream().filter((c) -> ((List<String>) c.get("Names")).contains("/container-prune-test")).findFirst();
+    assertTrue(toBePruned.isPresent());
+
+    ContainerPruneResponse pruneResponse = containerApi.containerPrune(filterJson);
+    assertTrue(pruneResponse.getContainersDeleted().contains(toBePruned.get().get("Id")));
+
+    Optional<Map<String, Object>> shouldBeMissing = containerApi.containerList(true, null, null, filterJson).stream().filter((c) -> ((List<String>) c.get("Names")).contains("/container-prune-test")).findFirst();
+    assertFalse(shouldBeMissing.isPresent());
+
+    removeContainer(engineApiClient, "container-prune-test");
+  }
+
+  // the api reference v1.41 says: "On Unix systems, this is done by running the ps command. This endpoint is not supported on Windows."
+  @Test
+  public void containerTop() {
+    imageApi.imageCreate(testImage.getImageName(), null, null, testImage.getImageTag(), null, null, null, null, null);
+
+    ContainerCreateRequest containerCreateRequest = new ContainerCreateRequest(
+        null, null, null,
+        false, false, false,
+        null,
+        false, null, null,
+        null,
+        null,
+        null,
+        null,
+        testImage.getImageWithTag(),
+        null, null, null,
+        null, null,
+        null,
+        singletonMap(LABEL_KEY, LABEL_VALUE),
+        null, null,
+        null,
+        null,
+        null
+    );
+    containerApi.containerCreate(containerCreateRequest, "container-top-test");
+    containerApi.containerStart("container-top-test", null);
+
+    ContainerTopResponse processes = containerApi.containerTop("container-top-test", null);
+    final String processTitle;
+    if (processes.getTitles().contains("CMD")) {
+      // Linux, macOS
+      processTitle = "CMD";
+    }
+    else {
+      // Windows
+      processTitle = "Name";
+    }
+    List<List<String>> mainProcesses = processes.getProcesses().stream().filter((p) -> p.get(processes.getTitles().indexOf(processTitle)).contains("main")).collect(Collectors.toList());
+
+    assertEquals(1, mainProcesses.size());
+
+    removeContainer(engineApiClient, "container-top-test");
+  }
+
+  @Test
+  public void containerStatsStream() {
+    imageApi.imageCreate(testImage.getImageName(), null, null, testImage.getImageTag(), null, null, null, null, null);
+
+    ContainerCreateRequest containerCreateRequest = new ContainerCreateRequest(
+        null, null, null,
+        false, false, false,
+        null,
+        false, null, null,
+        null,
+        null,
+        null,
+        null,
+        testImage.getImageWithTag(),
+        null, null, null,
+        null, null,
+        null,
+        singletonMap(LABEL_KEY, LABEL_VALUE),
+        null, null,
+        null,
+        null,
+        null
+    );
+    containerApi.containerCreate(containerCreateRequest, "container-stats-test");
+    containerApi.containerStart("container-stats-test", null);
+
+    Duration timeout = Duration.of(5, SECONDS);
+    LogObjectStreamCallback callback = new LogObjectStreamCallback();
+
+    containerApi.containerStats("container-stats-test", null, null, callback, timeout.toMillis());
+    assertFalse(callback.elements.isEmpty());
+
+    removeContainer(engineApiClient, "container-stats-test");
+  }
+
+  @Test
+  public void containerStatsOnce() {
+    imageApi.imageCreate(testImage.getImageName(), null, null, testImage.getImageTag(), null, null, null, null, null);
+
+    ContainerCreateRequest containerCreateRequest = new ContainerCreateRequest(
+        null, null, null,
+        false, false, false,
+        null,
+        false, null, null,
+        null,
+        null,
+        null,
+        null,
+        testImage.getImageWithTag(),
+        null, null, null,
+        null, null,
+        null,
+        singletonMap(LABEL_KEY, LABEL_VALUE),
+        null, null,
+        null,
+        null,
+        null
+    );
+    containerApi.containerCreate(containerCreateRequest, "container-stats-test");
+    containerApi.containerStart("container-stats-test", null);
+
+    Duration timeout = Duration.of(5, SECONDS);
+    LogObjectStreamCallback callback = new LogObjectStreamCallback();
+
+    containerApi.containerStats("container-stats-test", false, null, callback, timeout.toMillis());
+    assertFalse(callback.elements.isEmpty());
+
+    removeContainer(engineApiClient, "container-stats-test");
+  }
+
+  @Test
+  public void containerAttachNonInteractive() {
+    imageApi.imageCreate(testImage.getImageName(), null, null, testImage.getImageTag(), null, null, null, null, null);
+
+    ContainerCreateRequest containerCreateRequest = new ContainerCreateRequest(
+        null, null, null,
+        false, false, false,
+        null,
+        false, null, null,
+        null,
+        null,
+        null,
+        null,
+        testImage.getImageWithTag(),
+        null, null, null,
+        null, null,
+        null,
+        singletonMap(LABEL_KEY, LABEL_VALUE),
+        null, null,
+        null,
+        null,
+        null
+    );
+    containerApi.containerCreate(containerCreateRequest, "container-attach-non-interactive-test");
+    containerApi.containerStart("container-attach-non-interactive-test", null);
+
+    Duration timeout = Duration.of(5, SECONDS);
+    LogFrameStreamCallback callback = new LogFrameStreamCallback();
+
+    new Thread(() -> containerApi.containerAttach(
+        "container-attach-non-interactive-test",
+        null, true, true, null, true, true,
+        callback, timeout.toMillis())).start();
+
+    CountDownLatch wait = new CountDownLatch(1);
+    new Timer().schedule(new TimerTask() {
+      @Override
+      public void run() {
+        callback.job.cancel();
+        wait.countDown();
+      }
+    }, 5000);
+
+    try {
+      wait.await();
+    }
+    catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+    assertSame(callback.frames.stream().findAny().get().getStreamType(), Frame.StreamType.STDOUT);
+
+    removeContainer(engineApiClient, "container-attach-non-interactive-test");
+  }
+
+  static class LogFrameStreamCallback implements StreamCallback<Frame> {
+
+    List<Frame> frames = new ArrayList<>();
+    Cancellable job = null;
+
+    @Override
+    public void onStarting(Cancellable cancellable) {
+      job = cancellable;
+    }
+
+    @Override
+    public void onNext(Frame frame) {
+      frames.add(frame);
+      log.info("next: {}", frame);
+    }
+  }
+
+  static class LogObjectStreamCallback implements StreamCallback<Object> {
+
+    List<Object> elements = new ArrayList<>();
+    Cancellable job = null;
+
+    @Override
+    public void onStarting(Cancellable cancellable) {
+      job = cancellable;
+    }
+
+    @Override
+    public void onNext(Object element) {
+      elements.add(element);
+      log.info("next: {}", element);
+    }
+  }
+}

--- a/api-client/src/test/java/de/gesellix/docker/remote/api/client/DistributionApiIntegrationTest.java
+++ b/api-client/src/test/java/de/gesellix/docker/remote/api/client/DistributionApiIntegrationTest.java
@@ -1,0 +1,32 @@
+package de.gesellix.docker.remote.api.client;
+
+import de.gesellix.docker.remote.api.DistributionInspect;
+import de.gesellix.docker.remote.api.EngineApiClient;
+import de.gesellix.docker.remote.api.testutil.DockerEngineAvailable;
+import de.gesellix.docker.remote.api.testutil.InjectDockerClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DockerEngineAvailable
+class DistributionApiIntegrationTest {
+
+  @InjectDockerClient
+  private EngineApiClient engineApiClient;
+
+  DistributionApi distributionApi;
+
+  @BeforeEach
+  public void setup() {
+    distributionApi = engineApiClient.getDistributionApi();
+  }
+
+  @Test
+  public void distributionInspect() {
+    DistributionInspect response = distributionApi.distributionInspect("alpine:3.5");
+    assertNotNull(response.getDescriptor().getDigest());
+    assertTrue(response.getDescriptor().getDigest().startsWith("sha256:"));
+  }
+}

--- a/api-client/src/test/java/de/gesellix/docker/remote/api/client/ExecApiIntegrationTest.java
+++ b/api-client/src/test/java/de/gesellix/docker/remote/api/client/ExecApiIntegrationTest.java
@@ -1,0 +1,84 @@
+package de.gesellix.docker.remote.api.client;
+
+import de.gesellix.docker.remote.api.ContainerCreateRequest;
+import de.gesellix.docker.remote.api.EngineApiClient;
+import de.gesellix.docker.remote.api.ExecConfig;
+import de.gesellix.docker.remote.api.ExecInspectResponse;
+import de.gesellix.docker.remote.api.ExecStartConfig;
+import de.gesellix.docker.remote.api.IdResponse;
+import de.gesellix.docker.remote.api.testutil.DockerEngineAvailable;
+import de.gesellix.docker.remote.api.testutil.InjectDockerClient;
+import de.gesellix.docker.remote.api.testutil.TestImage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static de.gesellix.docker.remote.api.testutil.Constants.LABEL_KEY;
+import static de.gesellix.docker.remote.api.testutil.Constants.LABEL_VALUE;
+import static de.gesellix.docker.remote.api.testutil.Failsafe.removeContainer;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonMap;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@DockerEngineAvailable
+class ExecApiIntegrationTest {
+
+  @InjectDockerClient
+  private EngineApiClient engineApiClient;
+
+  private TestImage testImage;
+
+  ExecApi execApi;
+  ContainerApi containerApi;
+  ImageApi imageApi;
+
+  @BeforeEach
+  public void setup() {
+    execApi = engineApiClient.getExecApi();
+    containerApi = engineApiClient.getContainerApi();
+    imageApi = engineApiClient.getImageApi();
+    testImage = new TestImage(engineApiClient);
+  }
+
+  @Test
+  public void containerExec() {
+    imageApi.imageCreate(testImage.getImageName(), null, null, testImage.getImageTag(), null, null, null, null, null);
+
+    ContainerCreateRequest containerCreateRequest = new ContainerCreateRequest(
+        null, null, null,
+        false, false, false,
+        null,
+        false, null, null,
+        null,
+        null,
+        null,
+        null,
+        testImage.getImageWithTag(),
+        null, null, null,
+        null, null,
+        null,
+        singletonMap(LABEL_KEY, LABEL_VALUE),
+        null, null,
+        null,
+        null,
+        null
+    );
+    containerApi.containerCreate(containerCreateRequest, "container-exec-test");
+    containerApi.containerStart("container-exec-test", null);
+
+    IdResponse exec = execApi.containerExec(
+        "container-exec-test",
+        new ExecConfig(null, true, true, null, null,
+                       null,
+                       asList("echo", "'aus dem Wald'"),
+                       null, null, null));
+    assertNotNull(exec.getId());
+
+    execApi.execStart(exec.getId(), new ExecStartConfig(false, null));
+
+    ExecInspectResponse execInspect = execApi.execInspect(exec.getId());
+    assertFalse(execInspect.getRunning());
+
+    removeContainer(engineApiClient, "container-exec-test");
+  }
+}

--- a/api-client/src/test/java/de/gesellix/docker/remote/api/client/ImageApiIntegrationTest.java
+++ b/api-client/src/test/java/de/gesellix/docker/remote/api/client/ImageApiIntegrationTest.java
@@ -1,0 +1,272 @@
+package de.gesellix.docker.remote.api.client;
+
+import com.squareup.moshi.Moshi;
+import de.gesellix.docker.builder.BuildContextBuilder;
+import de.gesellix.docker.remote.api.BuildPruneResponse;
+import de.gesellix.docker.remote.api.ContainerCreateRequest;
+import de.gesellix.docker.remote.api.ContainerCreateResponse;
+import de.gesellix.docker.remote.api.EngineApiClient;
+import de.gesellix.docker.remote.api.HistoryResponseItem;
+import de.gesellix.docker.remote.api.IdResponse;
+import de.gesellix.docker.remote.api.Image;
+import de.gesellix.docker.remote.api.ImageDeleteResponseItem;
+import de.gesellix.docker.remote.api.ImageSearchResponseItem;
+import de.gesellix.docker.remote.api.ImageSummary;
+import de.gesellix.docker.remote.api.testutil.DockerEngineAvailable;
+import de.gesellix.docker.remote.api.testutil.DockerRegistry;
+import de.gesellix.docker.remote.api.testutil.HttpTestServer;
+import de.gesellix.docker.remote.api.testutil.InjectDockerClient;
+import de.gesellix.docker.remote.api.testutil.ManifestUtil;
+import de.gesellix.docker.remote.api.testutil.NetworkInterfaces;
+import de.gesellix.docker.remote.api.testutil.TarUtil;
+import de.gesellix.docker.remote.api.testutil.TestImage;
+import de.gesellix.testutil.ResourceReader;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.net.URL;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static de.gesellix.docker.remote.api.testutil.Constants.LABEL_KEY;
+import static de.gesellix.docker.remote.api.testutil.Constants.LABEL_VALUE;
+import static java.nio.file.Files.readAttributes;
+import static java.nio.file.LinkOption.NOFOLLOW_LINKS;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DockerEngineAvailable
+class ImageApiIntegrationTest {
+
+  @InjectDockerClient
+  private EngineApiClient engineApiClient;
+
+  private TestImage testImage;
+
+  ImageApi imageApi;
+  ContainerApi containerApi;
+
+  @BeforeEach
+  public void setup() {
+    imageApi = engineApiClient.getImageApi();
+    containerApi = engineApiClient.getContainerApi();
+    testImage = new TestImage(engineApiClient);
+  }
+
+  @Test
+  public void buildPrune() {
+    BuildPruneResponse response = imageApi.buildPrune(null, null, null);
+    assertTrue(response.getSpaceReclaimed() >= 0);
+  }
+
+  @Test
+  public void imageBuildAndPrune() throws IOException {
+    imageApi.imageTag(testImage.getImageWithTag(), "test", "build-base");
+    String dockerfile = "/images/builder/Dockerfile";
+    File inputDirectory = ResourceReader.getClasspathResourceAsFile(dockerfile, ImageApi.class).getParentFile();
+    InputStream buildContext = newBuildContext(inputDirectory);
+
+    assertDoesNotThrow(() -> imageApi.imageBuild(Paths.get(dockerfile).getFileName().toString(), "test:build", null, null, null, null, null, null,
+                                                 null, null, null, null, null, null, null,
+                                                 null, null, null, null, null, null, null,
+                                                 null, null, null, null, buildContext));
+
+    Map<String, List<String>> filter = new HashMap<>();
+    filter.put("label", singletonList(LABEL_KEY));
+    String filterJson = new Moshi.Builder().build().adapter(Map.class).toJson(filter);
+    assertDoesNotThrow(() -> imageApi.imagePrune(filterJson));
+
+    imageApi.imageDelete("test:build", null, null);
+    imageApi.imageDelete("test:build-base", null, null);
+  }
+
+  InputStream newBuildContext(File baseDirectory) throws IOException {
+    ByteArrayOutputStream buildContext = new ByteArrayOutputStream();
+    BuildContextBuilder.archiveTarFilesRecursively(baseDirectory, buildContext);
+    return new ByteArrayInputStream(buildContext.toByteArray());
+  }
+
+  @Test
+  public void imageCreatePullFromRemote() {
+    assertDoesNotThrow(() -> imageApi.imageCreate(testImage.getImageName(), null, null, testImage.getImageTag(), null, null, null, null, null));
+  }
+
+  @Test
+  public void imageCreateImportFromUrl() throws IOException {
+    File tarFile = imageApi.imageGet(testImage.getImageWithTag());
+    File destDir = new TarUtil().unTar(tarFile);
+    File rootLayerTar = new ManifestUtil().getRootLayerLocation(destDir);
+    URL importUrl = rootLayerTar.toURI().toURL();
+    HttpTestServer server = new HttpTestServer();
+    InetSocketAddress serverAddress = server.start("/images/", new HttpTestServer.FileServer(importUrl));
+    int port = serverAddress.getPort();
+    List<String> addresses = new NetworkInterfaces().getInet4Addresses();
+    String url = String.format("http://%s:%s/images/%s", addresses.get(0), port, importUrl.getPath());
+
+    assertDoesNotThrow(() -> imageApi.imageCreate(null, url, "test", "from-url", null, null, singletonList(String.format("LABEL %1$s=\"%2$s\"", LABEL_KEY, LABEL_VALUE)), null, null));
+
+    server.stop();
+    imageApi.imageDelete("test:from-url", null, null);
+  }
+
+  @Test
+  public void imageCreateImportFromInputStream() throws IOException {
+    File tarFile = imageApi.imageGet(testImage.getImageWithTag());
+    File destDir = new TarUtil().unTar(tarFile);
+    File rootLayerTar = new ManifestUtil().getRootLayerLocation(destDir);
+    try (InputStream source = new FileInputStream(rootLayerTar)) {
+      assertDoesNotThrow(() -> imageApi.imageCreate(null, "-", "test", "from-stream", null, null, singletonList(String.format("LABEL %1$s=\"%2$s\"", LABEL_KEY, LABEL_VALUE)), null, source));
+    }
+    imageApi.imageDelete("test:from-stream", null, null);
+  }
+
+  @Test
+  public void imageCommit() {
+    imageApi.imageTag(testImage.getImageWithTag(), "test", "commit");
+    ContainerCreateRequest containerCreateRequest = new ContainerCreateRequest(
+        null, null, null,
+        false, false, false,
+        null,
+        false, null, null,
+        null,
+        singletonList("-"),
+        null,
+        null,
+        "test:commit",
+        null, null, null,
+        null, null,
+        null,
+        singletonMap(LABEL_KEY, LABEL_VALUE),
+        null, null,
+        null,
+        null,
+        null
+    );
+    ContainerCreateResponse container = containerApi.containerCreate(containerCreateRequest, "container-commit-test");
+    IdResponse image = imageApi.imageCommit(container.getId(), "test", "committed", null, null, null, null, null);
+    assertTrue(image.getId().matches("sha256:\\w+"));
+    imageApi.imageDelete("test:committed", null, null);
+    containerApi.containerDelete("container-commit-test", null, null, null);
+    imageApi.imageDelete("test:commit", null, null);
+  }
+
+  @Test
+  public void imageList() {
+    List<ImageSummary> images = imageApi.imageList(null, null, null);
+    assertEquals(1, images.stream().filter((i) -> i.getRepoTags() != null && i.getRepoTags().stream().filter((t) -> t.equals(testImage.getImageWithTag())).count() > 0).count());
+  }
+
+  @Test
+  public void imageDelete() {
+    imageApi.imageTag(testImage.getImageWithTag(), "test", "delete");
+    List<ImageDeleteResponseItem> deletedImages = imageApi.imageDelete("test:delete", null, null);
+    assertTrue(deletedImages.stream().anyMatch((e) -> e.getDeleted() != null || e.getUntagged() != null));
+  }
+
+  @Test
+  public void imageGet() throws IOException {
+    imageApi.imageTag(testImage.getImageWithTag(), "test", "export");
+    File exportedImage = imageApi.imageGet("test:export");
+    assertTrue(16896 < Long.parseLong(readAttributes(exportedImage.toPath(), "size", NOFOLLOW_LINKS).get("size").toString()));
+
+    imageApi.imageDelete("test:export", null, null);
+  }
+
+  @Test
+  public void imageGetAll() throws IOException {
+    imageApi.imageTag(testImage.getImageWithTag(), "test", "export-all-1");
+    imageApi.imageTag(testImage.getImageWithTag(), "test", "export-all-2");
+
+    File exportedImages = imageApi.imageGetAll(asList("test:export-all-1", "test:export-all-2"));
+    assertTrue(22016 < Long.parseLong(readAttributes(exportedImages.toPath(), "size", NOFOLLOW_LINKS).get("size").toString()));
+
+    imageApi.imageDelete("test:export-all-1", null, null);
+    imageApi.imageDelete("test:export-all-2", null, null);
+  }
+
+  @Test
+  public void imageLoad() {
+    List<String> originalRepoDigests = imageApi.imageInspect(testImage.getImageWithTag()).getRepoDigests();
+
+    imageApi.imageTag(testImage.getImageWithTag(), "test", "load-image");
+    File tarFile = imageApi.imageGet("test:load-image");
+    imageApi.imageDelete("test:load-image", null, null);
+
+    assertDoesNotThrow(() -> imageApi.imageLoad(false, tarFile));
+
+    List<String> actualRepoDigests = imageApi.imageInspect("test:load-image").getRepoDigests();
+    assertEquals(originalRepoDigests, actualRepoDigests);
+
+    imageApi.imageDelete("test:load-image", null, null);
+  }
+
+  @Test
+  public void imageHistory() {
+    imageApi.imageTag(testImage.getImageWithTag(), "test", "history");
+
+    List<HistoryResponseItem> history = imageApi.imageHistory("test:history");
+    assertFalse(history.isEmpty());
+    Optional<HistoryResponseItem> historyItem = history.stream().filter(h -> h.getCreatedBy().contains("ENTRYPOINT [\"/main\"")).findFirst();
+    assertTrue(historyItem.isPresent());
+
+    imageApi.imageDelete("test:history", null, null);
+  }
+
+  @Test
+  public void imageInspect() {
+    imageApi.imageTag(testImage.getImageWithTag(), "test", "inspect");
+
+    Image image = imageApi.imageInspect("test:inspect");
+    assertTrue(image.getId().startsWith("sha256:"));
+
+    imageApi.imageDelete("test:inspect", null, null);
+  }
+
+  @Test
+  public void imageSearch() {
+    List<ImageSearchResponseItem> searchResult = imageApi.imageSearch("alpine", 1, null);
+    assertEquals(1, searchResult.size());
+    assertEquals("alpine", searchResult.get(0).getName());
+  }
+
+  @Test
+  public void imageTag() {
+    imageApi.imageTag(testImage.getImageWithTag(), "test/image", "test-tag");
+    Image image1 = imageApi.imageInspect(testImage.getImageWithTag());
+    Image image2 = imageApi.imageInspect("test/image:test-tag");
+    assertFalse(image1.getId().isEmpty());
+    assertEquals(image1.getId(), image2.getId());
+
+    imageApi.imageDelete("test/image:test-tag", null, null);
+  }
+
+  @Test
+  public void imagePushToCustomRegistry() {
+    DockerRegistry registry = new DockerRegistry(engineApiClient);
+    registry.run();
+    String registryUrl = registry.url();
+
+    imageApi.imageTag(testImage.getImageWithTag(), registryUrl + "/test", "push");
+
+    imageApi.imagePush(registryUrl + "/test", "", "push");
+
+    registry.rm();
+
+    imageApi.imageDelete(registryUrl + "/test:push", null, null);
+  }
+}

--- a/api-client/src/test/java/de/gesellix/docker/remote/api/client/NetworkApiIntegrationTest.java
+++ b/api-client/src/test/java/de/gesellix/docker/remote/api/client/NetworkApiIntegrationTest.java
@@ -1,0 +1,133 @@
+package de.gesellix.docker.remote.api.client;
+
+import com.squareup.moshi.Moshi;
+import de.gesellix.docker.remote.api.ContainerCreateRequest;
+import de.gesellix.docker.remote.api.EngineApiClient;
+import de.gesellix.docker.remote.api.Network;
+import de.gesellix.docker.remote.api.NetworkConnectRequest;
+import de.gesellix.docker.remote.api.NetworkCreateRequest;
+import de.gesellix.docker.remote.api.NetworkCreateResponse;
+import de.gesellix.docker.remote.api.NetworkDisconnectRequest;
+import de.gesellix.docker.remote.api.testutil.DockerEngineAvailable;
+import de.gesellix.docker.remote.api.testutil.InjectDockerClient;
+import de.gesellix.docker.remote.api.testutil.TestImage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static de.gesellix.docker.remote.api.testutil.Constants.LABEL_KEY;
+import static de.gesellix.docker.remote.api.testutil.Constants.LABEL_VALUE;
+import static de.gesellix.docker.remote.api.testutil.Failsafe.removeContainer;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DockerEngineAvailable
+class NetworkApiIntegrationTest {
+
+  @InjectDockerClient
+  private EngineApiClient engineApiClient;
+
+  private TestImage testImage;
+
+  NetworkApi networkApi;
+  ContainerApi containerApi;
+  ImageApi imageApi;
+
+  @BeforeEach
+  public void setup() {
+    networkApi = engineApiClient.getNetworkApi();
+    containerApi = engineApiClient.getContainerApi();
+    imageApi = engineApiClient.getImageApi();
+    testImage = new TestImage(engineApiClient);
+  }
+
+  @Test
+  public void networkList() {
+    List<Network> networks = networkApi.networkList(null);
+    assertFalse(networks.isEmpty());
+    Network firstNetwork = networks.get(0);
+    assertTrue(firstNetwork.getName().matches("\\w+"));
+  }
+
+  @Test
+  public void networkInspect() {
+    List<Network> networks = networkApi.networkList(null);
+    Network firstNetwork = networks.get(0);
+    Network network = networkApi.networkInspect(firstNetwork.getId(), true, firstNetwork.getScope());
+    assertEquals(firstNetwork.getScope(), network.getScope());
+  }
+
+  @Test
+  public void networkCreateDelete() {
+    NetworkCreateResponse response = networkApi.networkCreate(new NetworkCreateRequest("test-network", null, null, null, null, null, null, null, null, singletonMap(LABEL_KEY, LABEL_VALUE)));
+
+    Map<String, List<String>> filter = new HashMap<>();
+    filter.put("label", singletonList(LABEL_KEY));
+    String filterJson = new Moshi.Builder().build().adapter(Map.class).toJson(filter);
+    List<Network> networks = networkApi.networkList(filterJson);
+    Optional<Network> testNetwork = networks.stream().filter((n) -> n.getName().equals("test-network")).findFirst();
+
+    assertTrue(testNetwork.isPresent());
+    assertEquals(response.getId(), testNetwork.get().getId());
+    networkApi.networkDelete("test-network");
+  }
+
+  @Test
+  public void networkPrune() {
+    networkApi.networkCreate(new NetworkCreateRequest("test-network", null, null, null, null, null, null, null, null, singletonMap(LABEL_KEY, LABEL_VALUE)));
+
+    Map<String, List<String>> filter = new HashMap<>();
+    filter.put("label", singletonList(LABEL_KEY));
+    String filterJson = new Moshi.Builder().build().adapter(Map.class).toJson(filter);
+
+    networkApi.networkPrune(filterJson);
+
+    List<Network> networks = networkApi.networkList(filterJson);
+    Optional<Network> testNetwork = networks.stream().filter((n) -> n.getName().equals("test-network")).findAny();
+    assertFalse(testNetwork.isPresent());
+
+    assertDoesNotThrow(() -> networkApi.networkDelete("test-network"));
+  }
+
+  @Test
+  public void networkConnectDisconnect() {
+    imageApi.imageCreate(testImage.getImageName(), null, null, testImage.getImageTag(), null, null, null, null, null);
+
+    ContainerCreateRequest containerCreateRequest = new ContainerCreateRequest(
+        null, null, null,
+        false, false, false,
+        null,
+        false, null, null,
+        null,
+        null,
+        null,
+        null,
+        testImage.getImageWithTag(),
+        null, null, null,
+        null, null,
+        null,
+        singletonMap(LABEL_KEY, LABEL_VALUE),
+        null, null,
+        null,
+        null,
+        null
+    );
+    containerApi.containerCreate(containerCreateRequest, "container-network-test");
+
+    networkApi.networkCreate(new NetworkCreateRequest("test-network", null, null, null, null, null, null, null, null, singletonMap(LABEL_KEY, LABEL_VALUE)));
+
+    assertDoesNotThrow(() -> networkApi.networkConnect("test-network", new NetworkConnectRequest("container-network-test", null)));
+    assertDoesNotThrow(() -> networkApi.networkDisconnect("test-network", new NetworkDisconnectRequest("container-network-test", null)));
+
+    networkApi.networkDelete("test-network");
+    removeContainer(engineApiClient, "container-network-test");
+  }
+}

--- a/api-client/src/test/java/de/gesellix/docker/remote/api/client/NodeApiIntegrationTest.java
+++ b/api-client/src/test/java/de/gesellix/docker/remote/api/client/NodeApiIntegrationTest.java
@@ -1,0 +1,68 @@
+package de.gesellix.docker.remote.api.client;
+
+import de.gesellix.docker.remote.api.EngineApiClient;
+import de.gesellix.docker.remote.api.LocalNodeState;
+import de.gesellix.docker.remote.api.Node;
+import de.gesellix.docker.remote.api.NodeSpec;
+import de.gesellix.docker.remote.api.NodeState;
+import de.gesellix.docker.remote.api.core.ClientException;
+import de.gesellix.docker.remote.api.testutil.DockerEngineAvailable;
+import de.gesellix.docker.remote.api.testutil.InjectDockerClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static de.gesellix.docker.remote.api.testutil.Constants.LABEL_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DockerEngineAvailable(requiredSwarmMode = LocalNodeState.Active)
+class NodeApiIntegrationTest {
+
+  @InjectDockerClient
+  private EngineApiClient engineApiClient;
+
+  NodeApi nodeApi;
+
+  @BeforeEach
+  public void setup() {
+    nodeApi = engineApiClient.getNodeApi();
+  }
+
+  @Test
+  public void nodeListInspectUpdate() {
+    List<Node> nodes = nodeApi.nodeList(null);
+    assertFalse(nodes.isEmpty());
+    Node firstNode = nodes.get(0);
+    assertEquals(NodeState.Ready, firstNode.getStatus().getState());
+
+    Node node = nodeApi.nodeInspect(firstNode.getID());
+    assertEquals(firstNode.getID(), node.getID());
+
+    NodeSpec originalSpec = node.getSpec();
+    assertFalse(originalSpec.getLabels().containsKey(LABEL_KEY));
+
+    Map<String, String> labels = new HashMap<>(originalSpec.getLabels());
+    labels.put(LABEL_KEY, "temporary");
+    NodeSpec spec = new NodeSpec(originalSpec.getName(), labels, originalSpec.getRole(), originalSpec.getAvailability());
+    nodeApi.nodeUpdate(firstNode.getID(), node.getVersion().getIndex().longValue(), spec);
+
+    node = nodeApi.nodeInspect(firstNode.getID());
+    assertEquals(node.getSpec().getLabels().get(LABEL_KEY), "temporary");
+
+    nodeApi.nodeUpdate(firstNode.getID(), node.getVersion().getIndex().longValue(), originalSpec);
+  }
+
+  @Test
+  public void nodeDelete() {
+    List<Node> nodes = nodeApi.nodeList(null);
+    Node firstNode = nodes.get(0);
+    String error = assertThrows(ClientException.class, () -> nodeApi.nodeDelete(firstNode.getID(), false)).toString();
+    assertTrue(error.contains("FailedPrecondition"));
+  }
+}

--- a/api-client/src/test/java/de/gesellix/docker/remote/api/client/PluginApiIntegrationTest.java
+++ b/api-client/src/test/java/de/gesellix/docker/remote/api/client/PluginApiIntegrationTest.java
@@ -1,0 +1,44 @@
+package de.gesellix.docker.remote.api.client;
+
+import de.gesellix.docker.remote.api.EngineApiClient;
+import de.gesellix.docker.remote.api.Plugin;
+import de.gesellix.docker.remote.api.PluginPrivilege;
+import de.gesellix.docker.remote.api.testutil.DisabledIfDaemonOnWindowsOs;
+import de.gesellix.docker.remote.api.testutil.DockerEngineAvailable;
+import de.gesellix.docker.remote.api.testutil.InjectDockerClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@DockerEngineAvailable
+class PluginApiIntegrationTest {
+
+  @InjectDockerClient
+  private EngineApiClient engineApiClient;
+
+  PluginApi pluginApi;
+
+  @BeforeEach
+  public void setup() {
+    pluginApi = engineApiClient.getPluginApi();
+  }
+
+  @DisabledIfDaemonOnWindowsOs
+  @Test
+  public void pluginList() {
+    List<Plugin> plugins = pluginApi.pluginList(null);
+    assertNotNull(plugins);
+  }
+
+  @DisabledIfDaemonOnWindowsOs
+  @Test
+  public void pluginPrivileges() {
+    List<PluginPrivilege> privileges = pluginApi.getPluginPrivileges("vieux/sshfs");
+    assertEquals("host", privileges.stream().filter((p) -> Objects.equals(p.getName(), "network")).findFirst().get().getValue().get(0));
+  }
+}

--- a/api-client/src/test/java/de/gesellix/docker/remote/api/client/SecretApiIntegrationTest.java
+++ b/api-client/src/test/java/de/gesellix/docker/remote/api/client/SecretApiIntegrationTest.java
@@ -1,0 +1,97 @@
+package de.gesellix.docker.remote.api.client;
+
+import de.gesellix.docker.remote.api.EngineApiClient;
+import de.gesellix.docker.remote.api.IdResponse;
+import de.gesellix.docker.remote.api.LocalNodeState;
+import de.gesellix.docker.remote.api.Secret;
+import de.gesellix.docker.remote.api.SecretSpec;
+import de.gesellix.docker.remote.api.testutil.DockerEngineAvailable;
+import de.gesellix.docker.remote.api.testutil.InjectDockerClient;
+import de.gesellix.docker.remote.api.testutil.SwarmUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import static de.gesellix.docker.remote.api.testutil.Constants.LABEL_KEY;
+import static de.gesellix.docker.remote.api.testutil.Constants.LABEL_VALUE;
+import static java.util.Collections.singletonMap;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DockerEngineAvailable(requiredSwarmMode = LocalNodeState.Active)
+class SecretApiIntegrationTest {
+
+  @InjectDockerClient
+  private EngineApiClient engineApiClient;
+
+  SecretApi secretApi;
+
+  IdResponse defaultSecret;
+
+  SwarmUtil swarmUtil;
+
+  @BeforeEach
+  public void setup() {
+    secretApi = engineApiClient.getSecretApi();
+
+    swarmUtil = new SwarmUtil(engineApiClient);
+
+    String encoded = Base64.getEncoder().encodeToString("secret-data".getBytes());
+    defaultSecret = secretApi.secretCreate(new SecretSpec("secret-name", Collections.emptyMap(), encoded, null, null));
+  }
+
+  @AfterEach
+  public void cleanup() {
+    if (defaultSecret != null) {
+      secretApi.secretDelete(defaultSecret.getId());
+    }
+  }
+
+  @Test
+  public void secretCreate() {
+    String encoded = Base64.getEncoder().encodeToString("secret-data".getBytes());
+    IdResponse response = secretApi.secretCreate(new SecretSpec("my-secret", Collections.emptyMap(), encoded, null, null));
+    assertTrue(response.getId().matches("\\w{5,}"));
+
+    secretApi.secretDelete(response.getId());
+  }
+
+  @Test
+  public void secretDelete() {
+    String encoded = Base64.getEncoder().encodeToString("secret-data".getBytes());
+    IdResponse response = secretApi.secretCreate(new SecretSpec("my-secret", Collections.emptyMap(), encoded, null, null));
+
+    assertDoesNotThrow(() -> secretApi.secretDelete(response.getId()));
+  }
+
+  @Test
+  public void secretInspect() {
+    Secret inspect = secretApi.secretInspect(defaultSecret.getId());
+    assertEquals("secret-name", inspect.getSpec().getName());
+    assertNull(inspect.getSpec().getData());
+  }
+
+  @Test
+  public void secretList() {
+    List<Secret> secrets = secretApi.secretList(null);
+    Stream<Secret> filtered = secrets.stream().filter(c -> Objects.equals(c.getID(), defaultSecret.getId()));
+    assertEquals(defaultSecret.getId(), filtered.findFirst().orElse(new Secret()).getID());
+  }
+
+  @Test
+  public void secretUpdate() {
+    Secret inspect = secretApi.secretInspect(defaultSecret.getId());
+    SecretSpec secretSpec = inspect.getSpec();
+    assertNotNull(secretSpec);
+    assertDoesNotThrow(() -> secretApi.secretUpdate(defaultSecret.getId(), inspect.getVersion().getIndex(), new SecretSpec(secretSpec.getName(), singletonMap(LABEL_KEY, LABEL_VALUE), secretSpec.getData(), secretSpec.getDriver(), secretSpec.getTemplating())));
+  }
+}

--- a/api-client/src/test/java/de/gesellix/docker/remote/api/client/ServiceApiIntegrationTest.java
+++ b/api-client/src/test/java/de/gesellix/docker/remote/api/client/ServiceApiIntegrationTest.java
@@ -1,0 +1,220 @@
+package de.gesellix.docker.remote.api.client;
+
+import com.squareup.moshi.Moshi;
+import de.gesellix.docker.remote.api.EndpointPortConfig;
+import de.gesellix.docker.remote.api.EndpointSpec;
+import de.gesellix.docker.remote.api.EngineApiClient;
+import de.gesellix.docker.remote.api.LocalNodeState;
+import de.gesellix.docker.remote.api.Service;
+import de.gesellix.docker.remote.api.ServiceServiceStatus;
+import de.gesellix.docker.remote.api.ServiceSpec;
+import de.gesellix.docker.remote.api.ServiceSpecMode;
+import de.gesellix.docker.remote.api.ServiceSpecModeReplicated;
+import de.gesellix.docker.remote.api.ServiceSpecUpdateConfig;
+import de.gesellix.docker.remote.api.ServiceUpdateResponse;
+import de.gesellix.docker.remote.api.ServiceUpdateStatus;
+import de.gesellix.docker.remote.api.TaskSpec;
+import de.gesellix.docker.remote.api.TaskSpecContainerSpec;
+import de.gesellix.docker.remote.api.core.Cancellable;
+import de.gesellix.docker.remote.api.core.Frame;
+import de.gesellix.docker.remote.api.core.LoggingExtensionsKt;
+import de.gesellix.docker.remote.api.core.StreamCallback;
+import de.gesellix.docker.remote.api.testutil.DisabledIfDaemonOnWindowsOs;
+import de.gesellix.docker.remote.api.testutil.DockerEngineAvailable;
+import de.gesellix.docker.remote.api.testutil.InjectDockerClient;
+import de.gesellix.docker.remote.api.testutil.TestImage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static de.gesellix.docker.remote.api.EndpointPortConfig.Protocol.Tcp;
+import static de.gesellix.docker.remote.api.EndpointPortConfig.PublishMode.Ingress;
+import static de.gesellix.docker.remote.api.testutil.Constants.LABEL_KEY;
+import static de.gesellix.docker.remote.api.testutil.Constants.LABEL_VALUE;
+import static java.time.temporal.ChronoUnit.SECONDS;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DockerEngineAvailable(requiredSwarmMode = LocalNodeState.Active)
+class ServiceApiIntegrationTest {
+
+  private static final Logger log = LoggingExtensionsKt.logger(ServiceApiIntegrationTest.class.getName()).getValue();
+
+  @InjectDockerClient
+  private EngineApiClient engineApiClient;
+
+  private TestImage testImage;
+
+  ServiceApi serviceApi;
+
+  @BeforeEach
+  public void setup() {
+    serviceApi = engineApiClient.getServiceApi();
+    testImage = new TestImage(engineApiClient);
+  }
+
+  @Test
+  public void serviceList() {
+    List<Service> services = serviceApi.serviceList(null, null);
+    assertNotNull(services);
+  }
+
+  @DisabledIfDaemonOnWindowsOs
+  @Test
+  public void serviceLogs() throws InterruptedException {
+    // TODO fails on Windows
+    // "failed during hnsCallRawResponse: hnsCall failed in Win32: The parameter is incorrect. (0x57)"
+    // - https://github.com/moby/moby/issues/40621
+    // - https://github.com/moby/moby/issues/41094
+
+    serviceApi.serviceCreate(
+        new ServiceSpec("test-service", singletonMap(LABEL_KEY, LABEL_VALUE),
+                        new TaskSpec(null, new TaskSpecContainerSpec(testImage.getImageWithTag(), singletonMap(LABEL_KEY, LABEL_VALUE),
+                                                                     null, null, null, null, null,
+                                                                     null, null, null,
+                                                                     null, null, null, null,
+                                                                     null, null, null,
+                                                                     null, null, null, null,
+                                                                     null, null, null, null, null, null),
+                                     null, null, null, null, null, null, null, null),
+                        new ServiceSpecMode(new ServiceSpecModeReplicated(1L), null, null, null),
+                        new ServiceSpecUpdateConfig(1L, null, null, null, null, null),
+                        null, null,
+                        new EndpointSpec(null, singletonList(new EndpointPortConfig(null, Tcp, 8080, 8080, Ingress)))),
+        null);
+
+    CountDownLatch wait1 = new CountDownLatch(1);
+    Timer timer = new Timer();
+    timer.schedule(new TimerTask() {
+      @Override
+      public void run() {
+        Map<String, List<String>> filter = new HashMap<>();
+        filter.put("name", singletonList("test-service"));
+        String filterJson = new Moshi.Builder().build().adapter(Map.class).toJson(filter);
+        ServiceServiceStatus serviceStatus = serviceApi.serviceList(filterJson, true).get(0).getServiceStatus();
+        if (serviceStatus != null && serviceStatus.getRunningTasks() > 0) {
+          wait1.countDown();
+          timer.cancel();
+        }
+      }
+    }, 500, 500);
+    wait1.await(10, TimeUnit.SECONDS);
+    timer.cancel();
+
+    Duration timeout = Duration.of(5, SECONDS);
+    LogStreamCallback callback = new LogStreamCallback();
+
+    new Thread(() -> serviceApi.serviceLogs(
+        "test-service",
+        null, null, true, true, null, null, null,
+        callback, timeout.toMillis())).start();
+
+    CountDownLatch wait = new CountDownLatch(1);
+    new Timer().schedule(new TimerTask() {
+      @Override
+      public void run() {
+        callback.job.cancel();
+        wait.countDown();
+      }
+    }, 5000);
+
+    try {
+      wait.await();
+    }
+    catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+    serviceApi.serviceDelete("test-service");
+    assertSame(callback.frames.stream().findAny().get().getStreamType(), Frame.StreamType.STDOUT);
+  }
+
+  @Test
+  public void serviceCreateInspectUpdateDelete() throws InterruptedException {
+    serviceApi.serviceCreate(new ServiceSpec("test-service", singletonMap(LABEL_KEY, LABEL_VALUE),
+                                             new TaskSpec(null, new TaskSpecContainerSpec(testImage.getImageWithTag(), singletonMap(LABEL_KEY, LABEL_VALUE),
+                                                                                          null, null, null, null, null,
+                                                                                          null, null, null,
+                                                                                          null, null, null, null,
+                                                                                          null, null, null,
+                                                                                          null, null, null, null,
+                                                                                          null, null, null, null, null, null),
+                                                          null, null, null, null, null, null, null, null),
+                                             new ServiceSpecMode(new ServiceSpecModeReplicated(1L), null, null, null),
+                                             new ServiceSpecUpdateConfig(1L, null, null, null, null, null),
+                                             null, null,
+                                             new EndpointSpec(null, singletonList(new EndpointPortConfig(null, Tcp, 8080, 8080, Ingress)))),
+                             null);
+    // TODO TGe: we try to wait a bit to work around an error like '{"message":"rpc error: code = Unknown desc = update out of sequence"}'
+    Thread.sleep(5000);
+    Service serviceInspect = serviceApi.serviceInspect("test-service", false);
+    Integer serviceVersion = serviceInspect.getVersion().getIndex();
+    assertTrue(serviceVersion > 0);
+
+    Map<String, String> labels = new HashMap<>();
+    labels.putAll(serviceInspect.getSpec().getLabels());
+    labels.put("another-label", "another-value");
+    ServiceSpec spec = new ServiceSpec("test-service", labels,
+                                       new TaskSpec(null, new TaskSpecContainerSpec(testImage.getImageWithTag(), labels,
+                                                                                    null, null, null, null, null,
+                                                                                    null, null, null,
+                                                                                    null, null, null, null,
+                                                                                    null, null, null,
+                                                                                    null, null, null, null,
+                                                                                    null, null, null, null, null, null),
+                                                    null, null, null, null, null, null, null, null),
+                                       new ServiceSpecMode(new ServiceSpecModeReplicated(1L), null, null, null),
+                                       new ServiceSpecUpdateConfig(1L, null, null, null, null, null),
+                                       null, null,
+                                       new EndpointSpec(null, singletonList(new EndpointPortConfig(null, Tcp, 8080, 8080, Ingress))));
+    ServiceUpdateResponse updateResponse = serviceApi.serviceUpdate("test-service", serviceVersion, spec, null, null, null);
+    assertTrue(updateResponse.getWarnings() == null || updateResponse.getWarnings().isEmpty());
+
+    CountDownLatch wait = new CountDownLatch(1);
+    Timer timer = new Timer();
+    timer.schedule(new TimerTask() {
+      @Override
+      public void run() {
+        ServiceUpdateStatus updateStatus = serviceApi.serviceInspect("test-service", false).getUpdateStatus();
+        if (updateStatus.getState() == ServiceUpdateStatus.State.Completed) {
+          wait.countDown();
+          timer.cancel();
+        }
+      }
+    }, 500, 500);
+    wait.await(10, TimeUnit.SECONDS);
+    Service serviceInspect2 = serviceApi.serviceInspect("test-service", false);
+    assertEquals("another-value", serviceInspect2.getSpec().getLabels().get("another-label"));
+    serviceApi.serviceDelete("test-service");
+  }
+
+  static class LogStreamCallback implements StreamCallback<Frame> {
+
+    List<Frame> frames = new ArrayList<>();
+    Cancellable job = null;
+
+    @Override
+    public void onStarting(Cancellable cancellable) {
+      job = cancellable;
+    }
+
+    @Override
+    public void onNext(Frame frame) {
+      frames.add(frame);
+      log.info("next: {}", frame);
+    }
+  }
+}

--- a/api-client/src/test/java/de/gesellix/docker/remote/api/client/SwarmApiIntegrationTest.java
+++ b/api-client/src/test/java/de/gesellix/docker/remote/api/client/SwarmApiIntegrationTest.java
@@ -1,0 +1,70 @@
+package de.gesellix.docker.remote.api.client;
+
+import de.gesellix.docker.remote.api.EngineApiClient;
+import de.gesellix.docker.remote.api.LocalNodeState;
+import de.gesellix.docker.remote.api.Swarm;
+import de.gesellix.docker.remote.api.SwarmInitRequest;
+import de.gesellix.docker.remote.api.testutil.DockerEngineAvailable;
+import de.gesellix.docker.remote.api.testutil.InjectDockerClient;
+import de.gesellix.docker.remote.api.testutil.SwarmUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DockerEngineAvailable
+class SwarmApiIntegrationTest {
+
+  @InjectDockerClient
+  private EngineApiClient engineApiClient;
+
+  SwarmApi swarmApi;
+  SystemApi systemApi;
+
+  SwarmUtil swarmUtil;
+
+  @BeforeEach
+  public void setup() {
+    swarmApi = engineApiClient.getSwarmApi();
+    systemApi = engineApiClient.getSystemApi();
+
+    swarmUtil = new SwarmUtil(engineApiClient);
+  }
+
+  @Test
+  public void swarmLocalState() {
+    swarmUtil.runWithInactiveSwarm(() -> {
+      assertEquals(LocalNodeState.Inactive, systemApi.systemInfo().getSwarm().getLocalNodeState());
+    });
+  }
+
+  @Test
+  public void swarmInit() {
+    swarmUtil.runWithInactiveSwarm(() -> {
+      String initResult = swarmApi.swarmInit(new SwarmInitRequest("0.0.0.0:2377", "127.0.0.1", null, null, null, false, null, null));
+      assertTrue(initResult.matches("\\w+"));
+    });
+  }
+
+  @Test
+  public void swarmLeave() {
+    swarmUtil.runWithActiveSwarm(() -> {
+      assertDoesNotThrow(() -> swarmApi.swarmLeave(true));
+    });
+  }
+
+  @Test
+  public void swarmInspect() {
+    swarmUtil.runWithActiveSwarm(() -> {
+      Swarm swarmInspect = swarmApi.swarmInspect();
+      assertEquals("default", swarmInspect.getSpec().getName());
+    });
+  }
+
+  @Test
+  public void swarmUnlockKey() {
+    swarmUtil.runWithActiveSwarm(() -> assertDoesNotThrow(swarmApi::swarmUnlockkey));
+  }
+}

--- a/api-client/src/test/java/de/gesellix/docker/remote/api/client/SystemApiIntegrationTest.java
+++ b/api-client/src/test/java/de/gesellix/docker/remote/api/client/SystemApiIntegrationTest.java
@@ -1,0 +1,164 @@
+package de.gesellix.docker.remote.api.client;
+
+import de.gesellix.docker.authentication.AuthConfigReader;
+import de.gesellix.docker.remote.api.AuthConfig;
+import de.gesellix.docker.remote.api.EngineApiClient;
+import de.gesellix.docker.remote.api.EventMessage;
+import de.gesellix.docker.remote.api.SystemAuthResponse;
+import de.gesellix.docker.remote.api.SystemInfo;
+import de.gesellix.docker.remote.api.SystemVersion;
+import de.gesellix.docker.remote.api.core.Cancellable;
+import de.gesellix.docker.remote.api.core.ClientException;
+import de.gesellix.docker.remote.api.core.LoggingExtensionsKt;
+import de.gesellix.docker.remote.api.core.StreamCallback;
+import de.gesellix.docker.remote.api.testutil.DockerEngineAvailable;
+import de.gesellix.docker.remote.api.testutil.InjectDockerClient;
+import de.gesellix.docker.remote.api.testutil.TestImage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.CountDownLatch;
+
+import static java.time.temporal.ChronoUnit.SECONDS;
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DockerEngineAvailable
+class SystemApiIntegrationTest {
+
+  private static final Logger log = LoggingExtensionsKt.logger(SystemApiIntegrationTest.class.getName()).getValue();
+
+  @InjectDockerClient
+  private EngineApiClient engineApiClient;
+
+  private TestImage testImage;
+
+  SystemApi systemApi;
+  ImageApi imageApi;
+  ContainerApi containerApi;
+
+  @BeforeEach
+  public void setup() {
+    systemApi = engineApiClient.getSystemApi();
+    imageApi = engineApiClient.getImageApi();
+    containerApi = engineApiClient.getContainerApi();
+    testImage = new TestImage(engineApiClient);
+  }
+
+  @Test
+  public void systemAuthWhenUnauthorized() {
+    assertThrows(ClientException.class, () -> systemApi.systemAuth(new AuthConfig("unknown-username", "a-secret", "user@example.com", null)));
+  }
+
+  @Test
+  public void systemAuthWhenAuthorized() {
+    de.gesellix.docker.authentication.AuthConfig defaultAuthConfig = new AuthConfigReader().readDefaultAuthConfig();
+    SystemAuthResponse authResponse = systemApi.systemAuth(new AuthConfig(defaultAuthConfig.getUsername(), defaultAuthConfig.getPassword(), null, null));
+    assertEquals("Login Succeeded", authResponse.getStatus());
+  }
+
+  @Test
+  public void systemDataUsage() {
+    assertDoesNotThrow(() -> systemApi.systemDataUsage());
+  }
+
+  @Test
+  public void systemEvents() {
+    Duration timeout = Duration.of(20, SECONDS);
+    Instant since = ZonedDateTime.now().toInstant();
+    Instant until = ZonedDateTime.now().plus(timeout).plusSeconds(10).toInstant();
+    SystemEventsCallback callback = new SystemEventsCallback();
+
+    new Thread(() -> systemApi.systemEvents(
+        "" + since.getEpochSecond(),
+        "" + until.getEpochSecond(),
+        null,
+        callback,
+        timeout.toMillis())).start();
+
+    try {
+      Thread.sleep(10);
+    }
+    catch (InterruptedException e) {
+      log.warn("ignoring interrupted wait", e);
+    }
+
+    imageApi.imageTag(testImage.getImageWithTag(), "test", "system-events");
+    imageApi.imageDelete("test:system-events", null, null);
+
+    CountDownLatch wait = new CountDownLatch(1);
+    new Timer().schedule(new TimerTask() {
+      @Override
+      public void run() {
+        callback.job.cancel();
+        wait.countDown();
+      }
+    }, 1000);
+    try {
+      wait.await();
+    }
+    catch (InterruptedException e) {
+      log.warn("interrupted", e);
+    }
+
+    EventMessage event = callback.events.stream().filter(e -> Objects.equals(e.getAction(), "tag")).findFirst().orElse(new EventMessage());
+    assertEquals(EventMessage.Type.Image, event.getType());
+  }
+
+  @Test
+  public void systemInfo() {
+    SystemInfo systemInfo = systemApi.systemInfo();
+    assertEquals("docker.io", systemInfo.getRegistryConfig().getIndexConfigs().get("docker.io").getName());
+    assertTrue(systemInfo.getRegistryConfig().getIndexConfigs().get("docker.io").getOfficial());
+    assertTrue(systemInfo.getRegistryConfig().getIndexConfigs().get("docker.io").getSecure());
+    assertTrue(null == systemInfo.getIsolation() || asList(SystemInfo.Isolation.values()).contains(systemInfo.getIsolation()));
+  }
+
+  @Test
+  public void systemPing() {
+    String systemPing = systemApi.systemPing();
+    assertEquals("OK", systemPing);
+  }
+
+  @Test
+  public void systemPingHead() {
+    String systemPing = systemApi.systemPingHead();
+    assertEquals("", systemPing);
+  }
+
+  @Test
+  public void systemVersion() {
+    SystemVersion systemVersion = systemApi.systemVersion();
+    // will break on CI or in other environments - TODO fixme
+    assertEquals("1.41", systemVersion.getApiVersion());
+  }
+
+  static class SystemEventsCallback implements StreamCallback<EventMessage> {
+
+    List<EventMessage> events = new ArrayList<>();
+    Cancellable job = null;
+
+    @Override
+    public void onStarting(Cancellable cancellable) {
+      job = cancellable;
+    }
+
+    @Override
+    public void onNext(EventMessage event) {
+      events.add(event);
+      log.info("{}", event);
+    }
+  }
+}

--- a/api-client/src/test/java/de/gesellix/docker/remote/api/client/TaskApiIntegrationTest.java
+++ b/api-client/src/test/java/de/gesellix/docker/remote/api/client/TaskApiIntegrationTest.java
@@ -1,0 +1,211 @@
+package de.gesellix.docker.remote.api.client;
+
+import com.squareup.moshi.Moshi;
+import de.gesellix.docker.remote.api.EndpointPortConfig;
+import de.gesellix.docker.remote.api.EndpointSpec;
+import de.gesellix.docker.remote.api.EngineApiClient;
+import de.gesellix.docker.remote.api.LocalNodeState;
+import de.gesellix.docker.remote.api.ServiceCreateResponse;
+import de.gesellix.docker.remote.api.ServiceServiceStatus;
+import de.gesellix.docker.remote.api.ServiceSpec;
+import de.gesellix.docker.remote.api.ServiceSpecMode;
+import de.gesellix.docker.remote.api.ServiceSpecModeReplicated;
+import de.gesellix.docker.remote.api.ServiceSpecUpdateConfig;
+import de.gesellix.docker.remote.api.Task;
+import de.gesellix.docker.remote.api.TaskSpec;
+import de.gesellix.docker.remote.api.TaskSpecContainerSpec;
+import de.gesellix.docker.remote.api.core.Cancellable;
+import de.gesellix.docker.remote.api.core.Frame;
+import de.gesellix.docker.remote.api.core.LoggingExtensionsKt;
+import de.gesellix.docker.remote.api.core.StreamCallback;
+import de.gesellix.docker.remote.api.testutil.DisabledIfDaemonOnWindowsOs;
+import de.gesellix.docker.remote.api.testutil.DockerEngineAvailable;
+import de.gesellix.docker.remote.api.testutil.Failsafe;
+import de.gesellix.docker.remote.api.testutil.InjectDockerClient;
+import de.gesellix.docker.remote.api.testutil.TestImage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static de.gesellix.docker.remote.api.EndpointPortConfig.Protocol.Tcp;
+import static de.gesellix.docker.remote.api.EndpointPortConfig.PublishMode.Ingress;
+import static de.gesellix.docker.remote.api.testutil.Constants.LABEL_KEY;
+import static de.gesellix.docker.remote.api.testutil.Constants.LABEL_VALUE;
+import static java.time.temporal.ChronoUnit.SECONDS;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+@DockerEngineAvailable(requiredSwarmMode = LocalNodeState.Active)
+class TaskApiIntegrationTest {
+
+  private static final Logger log = LoggingExtensionsKt.logger(TaskApiIntegrationTest.class.getName()).getValue();
+
+  @InjectDockerClient
+  private EngineApiClient engineApiClient;
+
+  private TestImage testImage;
+
+  TaskApi taskApi;
+  ServiceApi serviceApi;
+
+  @BeforeEach
+  public void setup() {
+    taskApi = engineApiClient.getTaskApi();
+    serviceApi = engineApiClient.getServiceApi();
+    testImage = new TestImage(engineApiClient);
+  }
+
+  @Test
+  public void taskListInspect() throws InterruptedException {
+    ServiceCreateResponse service = serviceApi.serviceCreate(
+        new ServiceSpec("test-service", singletonMap(LABEL_KEY, LABEL_VALUE),
+                        new TaskSpec(null, new TaskSpecContainerSpec(testImage.getImageWithTag(), singletonMap(LABEL_KEY, LABEL_VALUE),
+                                                                     null, null, null, null, null,
+                                                                     null, null, null,
+                                                                     null, null, null, null,
+                                                                     null, null, null,
+                                                                     null, null, null, null,
+                                                                     null, null, null, null, null, null),
+                                     null, null, null, null, null, null, null, null),
+                        new ServiceSpecMode(new ServiceSpecModeReplicated(1L), null, null, null),
+                        new ServiceSpecUpdateConfig(1L, null, null, null, null, null),
+                        null, null,
+                        new EndpointSpec(null, singletonList(new EndpointPortConfig(null, Tcp, 8080, 8080, Ingress)))),
+        null);
+
+    CountDownLatch wait1 = new CountDownLatch(1);
+    Timer timer = new Timer();
+    timer.schedule(new TimerTask() {
+      @Override
+      public void run() {
+        Map<String, List<String>> filter = new HashMap<>();
+        filter.put("name", singletonList("test-service"));
+        String filterJson = new Moshi.Builder().build().adapter(Map.class).toJson(filter);
+        ServiceServiceStatus serviceStatus = serviceApi.serviceList(filterJson, true).get(0).getServiceStatus();
+        if (serviceStatus != null && serviceStatus.getRunningTasks() > 0) {
+          wait1.countDown();
+          timer.cancel();
+        }
+      }
+    }, 500, 500);
+    wait1.await(10, TimeUnit.SECONDS);
+    timer.cancel();
+
+    Map<String, List<String>> filter = new HashMap<>();
+    filter.put("service", singletonList("test-service"));
+    String filterJson = new Moshi.Builder().build().adapter(Map.class).toJson(filter);
+    List<Task> tasks = taskApi.taskList(filterJson);
+    assertFalse(tasks.isEmpty());
+
+    Task task = taskApi.taskInspect(tasks.stream().findFirst().get().getID());
+    assertEquals(service.getID(), task.getServiceID());
+
+    serviceApi.serviceDelete("test-service");
+  }
+
+  @DisabledIfDaemonOnWindowsOs
+  @Test
+  public void taskLogs() throws InterruptedException {
+    Failsafe.perform(() -> serviceApi.serviceDelete("test-service"));
+
+    // TODO fails on Windows
+    // "failed during hnsCallRawResponse: hnsCall failed in Win32: The parameter is incorrect. (0x57)"
+    // - https://github.com/moby/moby/issues/40621
+    // - https://github.com/moby/moby/issues/41094
+
+    ServiceCreateResponse service = serviceApi.serviceCreate(
+        new ServiceSpec("test-service", singletonMap(LABEL_KEY, LABEL_VALUE),
+                        new TaskSpec(null, new TaskSpecContainerSpec(testImage.getImageWithTag(), singletonMap(LABEL_KEY, LABEL_VALUE),
+                                                                     null, null, null, null, null,
+                                                                     null, null, null,
+                                                                     null, null, null, null,
+                                                                     null, null, null,
+                                                                     null, null, null, null,
+                                                                     null, null, null, null, null, null),
+                                     null, null, null, null, null, null, null, null),
+                        new ServiceSpecMode(new ServiceSpecModeReplicated(1L), null, null, null),
+                        new ServiceSpecUpdateConfig(1L, null, null, null, null, null),
+                        null, null,
+                        new EndpointSpec(null, singletonList(new EndpointPortConfig(null, Tcp, 8080, 8080, Ingress)))),
+        null);
+
+    CountDownLatch wait1 = new CountDownLatch(1);
+    Timer timer = new Timer();
+    timer.schedule(new TimerTask() {
+      @Override
+      public void run() {
+        Map<String, List<String>> filter = new HashMap<>();
+        filter.put("name", singletonList("test-service"));
+        String filterJson = new Moshi.Builder().build().adapter(Map.class).toJson(filter);
+        ServiceServiceStatus serviceStatus = serviceApi.serviceList(filterJson, true).get(0).getServiceStatus();
+        if (serviceStatus != null && serviceStatus.getRunningTasks() > 0) {
+          wait1.countDown();
+          timer.cancel();
+        }
+      }
+    }, 500, 500);
+    wait1.await(10, TimeUnit.SECONDS);
+    timer.cancel();
+
+    Map<String, List<String>> filter = new HashMap<>();
+    filter.put("service", singletonList("test-service"));
+    String filterJson = new Moshi.Builder().build().adapter(Map.class).toJson(filter);
+    List<Task> tasks = taskApi.taskList(filterJson);
+    Task task = tasks.stream().findFirst().get();
+
+    Duration timeout = Duration.of(5, SECONDS);
+    LogStreamCallback callback = new LogStreamCallback();
+
+    new Thread(() -> taskApi.taskLogs(task.getID(),
+                                      null, null, true, true, null, null, null,
+                                      callback, timeout.toMillis())).start();
+
+    CountDownLatch wait = new CountDownLatch(1);
+    new Timer().schedule(new TimerTask() {
+      @Override
+      public void run() {
+        callback.job.cancel();
+        wait.countDown();
+      }
+    }, 5000);
+
+    try {
+      wait.await();
+    }
+    catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+    serviceApi.serviceDelete("test-service");
+    assertSame(callback.frames.stream().findAny().get().getStreamType(), Frame.StreamType.STDOUT);
+  }
+
+  static class LogStreamCallback implements StreamCallback<Frame> {
+
+    List<Frame> frames = new ArrayList<>();
+    Cancellable job = null;
+
+    @Override
+    public void onStarting(Cancellable cancellable) {
+      job = cancellable;
+    }
+
+    @Override
+    public void onNext(Frame frame) {
+      frames.add(frame);
+      log.info("frame: {}", frame);
+    }
+  }
+}

--- a/api-client/src/test/java/de/gesellix/docker/remote/api/client/VolumeApiIntegrationTest.java
+++ b/api-client/src/test/java/de/gesellix/docker/remote/api/client/VolumeApiIntegrationTest.java
@@ -1,0 +1,82 @@
+package de.gesellix.docker.remote.api.client;
+
+import com.squareup.moshi.Moshi;
+import de.gesellix.docker.remote.api.EngineApiClient;
+import de.gesellix.docker.remote.api.Volume;
+import de.gesellix.docker.remote.api.VolumeConfig;
+import de.gesellix.docker.remote.api.VolumePruneResponse;
+import de.gesellix.docker.remote.api.testutil.DockerEngineAvailable;
+import de.gesellix.docker.remote.api.testutil.InjectDockerClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import static de.gesellix.docker.remote.api.testutil.Constants.LABEL_KEY;
+import static de.gesellix.docker.remote.api.testutil.Constants.LABEL_VALUE;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DockerEngineAvailable
+class VolumeApiIntegrationTest {
+
+  @InjectDockerClient
+  private EngineApiClient engineApiClient;
+
+  VolumeApi volumeApi;
+
+  String fileSeparator;
+
+  @BeforeEach
+  public void setup() {
+    volumeApi = engineApiClient.getVolumeApi();
+    boolean isWindowsDaemon = Objects.requireNonNull(engineApiClient.getSystemApi().systemVersion().getOs()).equalsIgnoreCase("windows");
+    fileSeparator = isWindowsDaemon ? "\\" : "/";
+  }
+
+  @Test
+  public void volumeCreate() {
+    Volume volume = volumeApi.volumeCreate(new VolumeConfig("my-volume", null, Collections.emptyMap(), Collections.emptyMap()));
+    assertTrue(volume.getMountpoint().endsWith(fileSeparator + "my-volume" + fileSeparator + "_data"));
+    volumeApi.volumeDelete(volume.getName(), false);
+  }
+
+  @Test
+  public void volumeDelete() {
+    Volume volume = volumeApi.volumeCreate(new VolumeConfig("my-volume", null, Collections.emptyMap(), Collections.emptyMap()));
+    assertDoesNotThrow(() -> volumeApi.volumeDelete(volume.getName(), false));
+  }
+
+  @Test
+  public void volumeInspect() {
+    volumeApi.volumeCreate(new VolumeConfig("my-volume", null, Collections.emptyMap(), Collections.emptyMap()));
+    Volume volume = volumeApi.volumeInspect("my-volume");
+    assertTrue(volume.getMountpoint().endsWith(fileSeparator + "my-volume" + fileSeparator + "_data"));
+    volumeApi.volumeDelete(volume.getName(), false);
+  }
+
+  @Test
+  public void volumeList() {
+    Volume volume = volumeApi.volumeCreate(new VolumeConfig("my-volume", null, Collections.emptyMap(), Collections.emptyMap()));
+    Optional<Volume> myVolume = volumeApi.volumeList(null).getVolumes().stream().filter((v) -> v.getName().equals(volume.getName())).findFirst();
+    assertEquals(volume.getMountpoint(), myVolume.orElse(new Volume("none", "none", "none", Collections.emptyMap(), Volume.Scope.Local, Collections.emptyMap(), "none", Collections.emptyMap(), null)).getMountpoint());
+    volumeApi.volumeDelete(volume.getName(), false);
+  }
+
+  @Test
+  public void volumePrune() {
+    Map<String, List<String>> filter = new HashMap<>();
+    filter.put("label", Collections.singletonList(LABEL_KEY));
+    String filterJson = new Moshi.Builder().build().adapter(Map.class).toJson(filter);
+
+    Volume volume = volumeApi.volumeCreate(new VolumeConfig("my-volume", null, Collections.emptyMap(), Collections.singletonMap(LABEL_KEY, LABEL_VALUE)));
+    VolumePruneResponse pruneResponse = volumeApi.volumePrune(filterJson);
+    assertTrue(Objects.requireNonNull(pruneResponse.getVolumesDeleted()).stream().allMatch((v) -> v.equals(volume.getName())));
+  }
+}

--- a/api-client/src/test/java/de/gesellix/docker/remote/api/testutil/Constants.java
+++ b/api-client/src/test/java/de/gesellix/docker/remote/api/testutil/Constants.java
@@ -1,0 +1,7 @@
+package de.gesellix.docker.remote.api.testutil;
+
+public interface Constants {
+
+  String LABEL_KEY = "de.gesellix.docker-client.test";
+  String LABEL_VALUE = "1";
+}

--- a/api-client/src/test/java/de/gesellix/docker/remote/api/testutil/DisabledIfDaemonOnWindowsOs.java
+++ b/api-client/src/test/java/de/gesellix/docker/remote/api/testutil/DisabledIfDaemonOnWindowsOs.java
@@ -1,0 +1,44 @@
+package de.gesellix.docker.remote.api.testutil;
+
+import de.gesellix.docker.remote.api.EngineApiClient;
+import de.gesellix.docker.remote.api.EngineApiClientImpl;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Objects;
+
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(DisabledIfDaemonOnWindowsOs.WindowsDaemonCondition.class)
+public @interface DisabledIfDaemonOnWindowsOs {
+
+  class WindowsDaemonCondition implements ExecutionCondition {
+
+    private final EngineApiClient engineApiClient;
+
+    public WindowsDaemonCondition() {
+      engineApiClient = new EngineApiClientImpl();
+    }
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+      return isWindowsDaemon()
+             ? disabled("Disabled: Windows daemon detected")
+             : enabled("Enabled: Non-Windows daemon detected");
+    }
+
+    public boolean isWindowsDaemon() {
+      return Objects.requireNonNull(engineApiClient.getSystemApi().systemVersion().getOs())
+          .equalsIgnoreCase("windows");
+    }
+  }
+}

--- a/api-client/src/test/java/de/gesellix/docker/remote/api/testutil/DisabledIfNotPausable.java
+++ b/api-client/src/test/java/de/gesellix/docker/remote/api/testutil/DisabledIfNotPausable.java
@@ -1,0 +1,54 @@
+package de.gesellix.docker.remote.api.testutil;
+
+import de.gesellix.docker.remote.api.EngineApiClient;
+import de.gesellix.docker.remote.api.EngineApiClientImpl;
+import de.gesellix.docker.remote.api.SystemInfo;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Objects;
+
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(DisabledIfNotPausable.WindowsContainerPausableCondition.class)
+public @interface DisabledIfNotPausable {
+
+  class WindowsContainerPausableCondition implements ExecutionCondition {
+
+    private final EngineApiClient engineApiClient;
+
+    public WindowsContainerPausableCondition() {
+      engineApiClient = new EngineApiClientImpl();
+    }
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+      return isPausable()
+             ? enabled("Enabled: Non-Windows Server daemon detected")
+             : disabled("Disabled: cannot pause Windows Server Containers");
+    }
+
+    public boolean isPausable() {
+      SystemInfo systemInfo = engineApiClient.getSystemApi().systemInfo();
+      return !isWindowsDaemon(systemInfo) || !isDaemonIsolationByProcess(systemInfo);
+    }
+
+    public boolean isDaemonIsolationByProcess(SystemInfo systemInfo) {
+      return systemInfo.getIsolation() == SystemInfo.Isolation.Process;
+    }
+
+    public boolean isWindowsDaemon(SystemInfo systemInfo) {
+      return Objects.requireNonNull(systemInfo.getOsType())
+          .equalsIgnoreCase("windows");
+    }
+  }
+}

--- a/api-client/src/test/java/de/gesellix/docker/remote/api/testutil/DockerEngineAvailable.java
+++ b/api-client/src/test/java/de/gesellix/docker/remote/api/testutil/DockerEngineAvailable.java
@@ -1,0 +1,116 @@
+package de.gesellix.docker.remote.api.testutil;
+
+import de.gesellix.docker.remote.api.EngineApiClient;
+import de.gesellix.docker.remote.api.EngineApiClientImpl;
+import de.gesellix.docker.remote.api.LocalNodeState;
+import de.gesellix.docker.remote.api.core.LoggingExtensionsKt;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionConfigurationException;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestInstancePostProcessor;
+import org.junit.jupiter.api.extension.TestInstancePreDestroyCallback;
+import org.junit.platform.commons.support.HierarchyTraversalMode;
+import org.junit.platform.commons.support.ReflectionSupport;
+import org.slf4j.Logger;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Field;
+import java.util.List;
+
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@ExtendWith(DockerEngineAvailable.DockerEngineAvailableCondition.class)
+public @interface DockerEngineAvailable {
+
+  Logger log = LoggingExtensionsKt.logger(DockerEngineAvailable.class.getName()).getValue();
+
+  LocalNodeState requiredSwarmMode() default LocalNodeState.EMPTY;
+
+  class DockerEngineAvailableCondition implements ExecutionCondition, TestInstancePostProcessor, TestInstancePreDestroyCallback {
+
+    private final EngineApiClient engineApiClient;
+    private final SwarmUtil swarmUtil;
+    private LocalNodeState requiredSwarmMode;
+    private LocalNodeState previousNodeState = LocalNodeState.EMPTY;
+
+    public DockerEngineAvailableCondition() {
+      engineApiClient = new EngineApiClientImpl();
+      swarmUtil = new SwarmUtil(engineApiClient);
+    }
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+      return available()
+             ? enabled("Docker Engine is available")
+             : disabled("Docker Engine is not available");
+    }
+
+    boolean available() {
+      try {
+        engineApiClient.getSystemApi().systemPing();
+        return true;
+      }
+      catch (Exception e) {
+        log.warn("Docker not available");
+        return false;
+      }
+    }
+
+    @Override
+    public void postProcessTestInstance(Object testInstance, ExtensionContext context) throws Exception {
+      initDockerClientField(testInstance);
+
+      requiredSwarmMode = testInstance.getClass().getAnnotation(DockerEngineAvailable.class).requiredSwarmMode();
+      switch (requiredSwarmMode) {
+        case Active:
+          previousNodeState = swarmUtil.ensureActiveSwarm();
+          break;
+        case Inactive:
+          previousNodeState = swarmUtil.ensureInactiveSwarm();
+          break;
+        case EMPTY:
+          // don't change anything
+          break;
+        default:
+          throw new ExtensionConfigurationException("Not supported: " + requiredSwarmMode);
+      }
+    }
+
+    private void initDockerClientField(Object testInstance) throws IllegalAccessException {
+      List<Field> fields = ReflectionSupport.findFields(testInstance.getClass(), (Field f) -> f.getAnnotation(InjectDockerClient.class) != null, HierarchyTraversalMode.TOP_DOWN);
+      if (fields.isEmpty()) {
+        throw new ExtensionConfigurationException(String.format("No %1$s annotated field found in %2$s.", InjectDockerClient.class, testInstance.getClass()));
+      }
+      if (fields.size() > 1) {
+        throw new ExtensionConfigurationException(String.format("Multiple fields annotated with %1$s found in %2$s.", InjectDockerClient.class, testInstance.getClass()));
+      }
+      Field dockerClientField = fields.get(0);
+      dockerClientField.setAccessible(true);
+      dockerClientField.set(testInstance, engineApiClient);
+    }
+
+    @Override
+    public void preDestroyTestInstance(ExtensionContext context) {
+      if (previousNodeState != requiredSwarmMode) {
+        switch (previousNodeState) {
+          case Active:
+            swarmUtil.ensureActiveSwarm();
+            break;
+          case Inactive:
+            swarmUtil.ensureInactiveSwarm();
+            break;
+          default:
+            log.warn("Won't revert LocalNodeState back to {}", previousNodeState);
+        }
+      }
+    }
+  }
+}

--- a/api-client/src/test/java/de/gesellix/docker/remote/api/testutil/DockerRegistry.java
+++ b/api-client/src/test/java/de/gesellix/docker/remote/api/testutil/DockerRegistry.java
@@ -1,0 +1,97 @@
+package de.gesellix.docker.remote.api.testutil;
+
+import de.gesellix.docker.remote.api.ContainerCreateRequest;
+import de.gesellix.docker.remote.api.ContainerCreateResponse;
+import de.gesellix.docker.remote.api.ContainerInspectResponse;
+import de.gesellix.docker.remote.api.EngineApiClient;
+import de.gesellix.docker.remote.api.EngineApiClientImpl;
+import de.gesellix.docker.remote.api.HostConfig;
+import de.gesellix.docker.remote.api.PortBinding;
+
+import java.util.List;
+import java.util.Objects;
+
+import static de.gesellix.docker.remote.api.testutil.Constants.LABEL_KEY;
+import static de.gesellix.docker.remote.api.testutil.Constants.LABEL_VALUE;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+
+public class DockerRegistry {
+
+  EngineApiClient engineApiClient;
+  String registryId;
+
+  public static void main(String[] args) throws InterruptedException {
+    DockerRegistry registry = new DockerRegistry(new EngineApiClientImpl());
+    registry.run();
+    Thread.sleep(10000);
+    registry.rm();
+  }
+
+  public DockerRegistry(EngineApiClient engineApiClient) {
+    this.engineApiClient = engineApiClient;
+  }
+
+  String getImage() {
+//    dockerClient.getSystemApi().systemInfo().getOsType()
+    boolean isWindows = Objects.requireNonNull(engineApiClient.getSystemApi().systemVersion().getOs()).equalsIgnoreCase("windows");
+    return isWindows ? "gesellix/registry:2.7.1-windows" : "registry:2.7.1";
+  }
+
+  public void run() {
+    ContainerCreateRequest containerCreateRequest = new ContainerCreateRequest(
+        null, null, null,
+        false, false, false,
+        singletonMap("5000/tcp", emptyMap()),
+        false, null, null,
+        null,
+        null,
+        null,
+        null,
+        getImage(),
+        null, null, null,
+        null, null,
+        null,
+        singletonMap(LABEL_KEY, LABEL_VALUE),
+        null, null,
+        null,
+        new HostConfig(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+                       null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+                       null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+                       null, null, true, null, null, null, null, null, null, null, null, null, null, null, null, null),
+        null
+    );
+    engineApiClient.getImageApi().imageCreate(containerCreateRequest.getImage().split(":")[0], null, null, containerCreateRequest.getImage().split(":")[1], null, null, null, null, null);
+    ContainerCreateResponse createResponse = engineApiClient.getContainerApi().containerCreate(containerCreateRequest, null);
+    engineApiClient.getContainerApi().containerStart(createResponse.getId(), null);
+    registryId = createResponse.getId();
+  }
+
+  String address() {
+//        String dockerHost = dockerClient.config.dockerHost
+//        return dockerHost.replaceAll("^(tcp|http|https)://", "").replaceAll(":\\d+\$", "")
+
+//        def registryContainer = dockerClient.inspectContainer(registryId).content
+//        def portBinding = registryContainer.NetworkSettings.Ports["5000/tcp"]
+//        return portBinding[0].HostIp as String
+
+    // 'localhost' allows to use the registry without TLS
+    return "localhost";
+  }
+
+  int port() {
+    ContainerInspectResponse registryContainer = engineApiClient.getContainerApi().containerInspect(registryId, false);
+    List<PortBinding> portBinding = registryContainer.getNetworkSettings().getPorts().get("5000/tcp");
+    return Integer.parseInt(portBinding.stream().findFirst().get().getHostPort());
+  }
+
+  public String url() {
+    return address() + ":" + port();
+  }
+
+  public void rm() {
+    engineApiClient.getContainerApi().containerStop(registryId, null);
+    engineApiClient.getContainerApi().containerWait(registryId, null);
+    engineApiClient.getContainerApi().containerDelete(registryId, null, null, null);
+  }
+}

--- a/api-client/src/test/java/de/gesellix/docker/remote/api/testutil/Failsafe.java
+++ b/api-client/src/test/java/de/gesellix/docker/remote/api/testutil/Failsafe.java
@@ -1,0 +1,21 @@
+package de.gesellix.docker.remote.api.testutil;
+
+import de.gesellix.docker.remote.api.EngineApiClient;
+
+public class Failsafe {
+
+  public static void removeContainer(EngineApiClient engineApiClient, String container) {
+    perform(() -> engineApiClient.getContainerApi().containerStop(container, 5));
+    perform(() -> engineApiClient.getContainerApi().containerWait(container, null));
+    perform(() -> engineApiClient.getContainerApi().containerDelete(container, null, null, null));
+  }
+
+  public static void perform(Runnable action) {
+    try {
+      action.run();
+    }
+    catch (Exception e) {
+      System.out.println("ignoring " + e.getMessage());
+    }
+  }
+}

--- a/api-client/src/test/java/de/gesellix/docker/remote/api/testutil/HttpTestServer.java
+++ b/api-client/src/test/java/de/gesellix/docker/remote/api/testutil/HttpTestServer.java
@@ -1,0 +1,187 @@
+package de.gesellix.docker.remote.api.testutil;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import com.sun.net.httpserver.HttpsConfigurator;
+import com.sun.net.httpserver.HttpsServer;
+import okio.BufferedSink;
+import okio.Okio;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.URL;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+
+public class HttpTestServer {
+
+  private HttpServer httpServer;
+  private final SSLContext sslContext;
+
+  public HttpTestServer() {
+    this(null);
+  }
+
+  public HttpTestServer(SSLContext sslContext) {
+    this.sslContext = sslContext;
+  }
+
+  public InetSocketAddress start() throws IOException {
+    return start("/test/", new ReverseHandler());
+  }
+
+  public InetSocketAddress start(final String context, final HttpHandler handler) throws IOException {
+    InetSocketAddress address = new InetSocketAddress(0);
+
+    if (sslContext != null) {
+      // using the VM param `-Djavax.net.debug=all` helps debugging SSL issues
+      httpServer = HttpsServer.create(address, address.getPort());
+      ((HttpsServer) httpServer).setHttpsConfigurator(new DefaultHttpsConfigurator(sslContext));
+    }
+    else {
+      httpServer = HttpServer.create(address, address.getPort());
+    }
+
+    httpServer.createContext(context, handler);
+    httpServer.setExecutor(Executors.newCachedThreadPool());
+    httpServer.start();
+    return httpServer.getAddress();
+  }
+
+  public void stop() {
+    if (httpServer != null) {
+      httpServer.stop(0);
+    }
+  }
+
+  /**
+   * Given your KeyStore is located in the classpath at "/de/gesellix/docker/testutil/test.jks",
+   * you may call the method like in this example:
+   *
+   * <pre>
+   * <code>
+   * SSLContext ctx = HttpTestServer.createDefaultSSLContext("/de/gesellix/docker/testutil/test.jks", "changeit")
+   * </code>
+   * </pre>
+   *
+   * If you need a new KeyStore from scratch you can use this command:
+   *
+   * <pre>
+   * <code>
+   * keytool -genkey -alias alias -keypass changeit -keystore test.jks -storepass changeit
+   * </code>
+   * </pre>
+   *
+   * Please note that you should enter a valid domain (e.g. "localhost")
+   * when being asked for your first and last name ("CN").
+   */
+  public static SSLContext createDefaultSSLContext(String jksResource, String jksPassword) throws NoSuchAlgorithmException, KeyStoreException, CertificateException, IOException, UnrecoverableKeyException, KeyManagementException {
+    InputStream jksInputStream = HttpTestServer.class.getResourceAsStream(jksResource);
+    char[] password = jksPassword.toCharArray();
+    KeyStore ks = KeyStore.getInstance("JKS");
+    ks.load(jksInputStream, password);
+
+    KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+    kmf.init(ks, password);
+
+    TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+    tmf.init(ks);
+
+    SSLContext sslContext = SSLContext.getInstance("TLS");
+    sslContext.init(kmf.getKeyManagers(), tmf.getTrustManagers(), new SecureRandom());
+    return sslContext;
+  }
+
+  public static class DefaultHttpsConfigurator extends HttpsConfigurator {
+
+    public DefaultHttpsConfigurator(SSLContext sslContext) {
+      super(sslContext);
+    }
+  }
+
+  public static class ReverseHandler implements HttpHandler {
+
+    @Override
+    public void handle(HttpExchange httpExchange) throws IOException {
+      if (httpExchange.getRequestMethod().equals("GET")) {
+        httpExchange.getResponseHeaders().set("Content-Type", "text/plain");
+        final String query = httpExchange.getRequestURI().getRawQuery();
+
+        if (query == null || !query.contains("string")) {
+          httpExchange.sendResponseHeaders(400, 0);
+          return;
+        }
+
+        final String[] param = query.split("=");
+        assert param.length == 2 && param[0].equals("string");
+
+        httpExchange.sendResponseHeaders(200, 0);
+        httpExchange.getResponseBody().write(new StringBuilder(param[1]).reverse().toString().getBytes());
+        httpExchange.getResponseBody().close();
+      }
+    }
+  }
+
+  public static class RecordingRequestsHandler implements HttpHandler {
+
+    private final List<String> recordedRequests = new ArrayList<>();
+    private final Map<String, Map<String, List<String>>> recordedHeadersByRequest = new HashMap<>();
+
+    @Override
+    public void handle(final HttpExchange httpExchange) throws IOException {
+      String request = httpExchange.getRequestMethod() + " " + httpExchange.getRequestURI();
+      recordedRequests.add(request);
+      recordedHeadersByRequest.put(request, httpExchange.getRequestHeaders());
+
+      httpExchange.sendResponseHeaders(200, 0);
+    }
+
+    public List<String> getRecordedRequests() {
+      return recordedRequests;
+    }
+
+    public Map<String, Map<String, List<String>>> getRecordedHeadersByRequest() {
+      return recordedHeadersByRequest;
+    }
+  }
+
+  public static class FileServer implements HttpHandler {
+
+    private final URL file;
+
+    public FileServer(URL file) {
+      this.file = file;
+    }
+
+    @Override
+    public void handle(HttpExchange httpExchange) throws IOException {
+      if (httpExchange.getRequestMethod().equals("GET")) {
+        httpExchange.sendResponseHeaders(200, 0);
+        copy(file.openStream(), httpExchange.getResponseBody());
+        httpExchange.getResponseBody().close();
+      }
+    }
+
+    private void copy(InputStream source, OutputStream sink) throws IOException {
+      BufferedSink bufferedSink = Okio.buffer(Okio.sink(sink));
+      bufferedSink.writeAll(Okio.buffer(Okio.source(source)));
+      bufferedSink.flush();
+    }
+  }
+}

--- a/api-client/src/test/java/de/gesellix/docker/remote/api/testutil/InjectDockerClient.java
+++ b/api-client/src/test/java/de/gesellix/docker/remote/api/testutil/InjectDockerClient.java
@@ -1,0 +1,12 @@
+package de.gesellix.docker.remote.api.testutil;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface InjectDockerClient {
+
+}

--- a/api-client/src/test/java/de/gesellix/docker/remote/api/testutil/ManifestUtil.java
+++ b/api-client/src/test/java/de/gesellix/docker/remote/api/testutil/ManifestUtil.java
@@ -1,0 +1,25 @@
+package de.gesellix.docker.remote.api.testutil;
+
+import com.squareup.moshi.Moshi;
+import okio.Okio;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class ManifestUtil {
+
+  private final Moshi moshi;
+
+  public ManifestUtil() {
+    this.moshi = new Moshi.Builder().build();
+  }
+
+  public File getRootLayerLocation(File baseDir) throws IOException {
+    File manifest = new File(baseDir, "manifest.json");
+    Map manifestEntry = (Map) moshi.adapter(List.class).fromJson(Okio.buffer(Okio.source(manifest))).get(0);
+    return new File(baseDir, ((String) ((List) manifestEntry.get("Layers")).get(0)));
+//    return new File(destDir, ((String) ((List) manifestEntry.get("Layers")).get(0)).replaceAll("/", File.separator));
+  }
+}

--- a/api-client/src/test/java/de/gesellix/docker/remote/api/testutil/NetworkInterfaces.java
+++ b/api-client/src/test/java/de/gesellix/docker/remote/api/testutil/NetworkInterfaces.java
@@ -1,0 +1,43 @@
+package de.gesellix.docker.remote.api.testutil;
+
+import de.gesellix.docker.remote.api.core.LoggingExtensionsKt;
+import org.slf4j.Logger;
+
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+// https://docs.oracle.com/javase/tutorial/networking/nifs/listing.html
+public class NetworkInterfaces {
+
+  private static final Logger log = LoggingExtensionsKt.logger(NetworkInterfaces.class.getName()).getValue();
+
+  public static void main(String[] args) throws SocketException {
+    log.info(new NetworkInterfaces().getFirstInet4Address());
+  }
+
+  public String getFirstInet4Address() throws SocketException {
+    return getInet4Addresses().stream().findFirst().get();
+  }
+
+  public List<String> getInet4Addresses() throws SocketException {
+    List<NetworkInterface> interfaces = Collections.list(NetworkInterface.getNetworkInterfaces());
+    return interfaces.stream()
+        .flatMap((i) -> getInet4Addresses(i))
+        .filter(Objects::nonNull)
+        .collect(Collectors.toList());
+  }
+
+  public static Stream<String> getInet4Addresses(NetworkInterface netint) {
+    List<InetAddress> addresses = Collections.list(netint.getInetAddresses());
+    return addresses.stream()
+        .filter((it) -> it instanceof Inet4Address && !it.isLoopbackAddress())
+        .map((it) -> it.getHostAddress());
+  }
+}

--- a/api-client/src/test/java/de/gesellix/docker/remote/api/testutil/SwarmUtil.java
+++ b/api-client/src/test/java/de/gesellix/docker/remote/api/testutil/SwarmUtil.java
@@ -1,0 +1,70 @@
+package de.gesellix.docker.remote.api.testutil;
+
+import de.gesellix.docker.remote.api.EngineApiClient;
+import de.gesellix.docker.remote.api.LocalNodeState;
+import de.gesellix.docker.remote.api.SwarmInitRequest;
+import de.gesellix.docker.remote.api.client.SwarmApi;
+import de.gesellix.docker.remote.api.client.SystemApi;
+
+public class SwarmUtil {
+
+  SwarmApi swarmApi;
+  SystemApi systemApi;
+
+  public SwarmUtil(EngineApiClient engineApiClient) {
+    this.swarmApi = engineApiClient.getSwarmApi();
+    this.systemApi = engineApiClient.getSystemApi();
+  }
+
+  public void runWithInactiveSwarm(Runnable action) {
+    LocalNodeState previousState = ensureInactiveSwarm();
+    try {
+      action.run();
+    }
+    finally {
+      if (previousState != LocalNodeState.Inactive) {
+        ensureActiveSwarm();
+      }
+    }
+  }
+
+  public void runWithActiveSwarm(Runnable action) {
+    LocalNodeState previousState = ensureActiveSwarm();
+    try {
+      action.run();
+    }
+    finally {
+      if (previousState != LocalNodeState.Active) {
+        ensureInactiveSwarm();
+      }
+    }
+  }
+
+  LocalNodeState ensureInactiveSwarm() {
+    LocalNodeState currentState = null;
+    try {
+      currentState = systemApi.systemInfo().getSwarm().getLocalNodeState();
+      if (currentState != LocalNodeState.Inactive) {
+        swarmApi.swarmLeave(true);
+      }
+    }
+    catch (Exception ignored) {
+      //
+    }
+    return currentState;
+  }
+
+  LocalNodeState ensureActiveSwarm() {
+    LocalNodeState currentState = null;
+    try {
+      currentState = systemApi.systemInfo().getSwarm().getLocalNodeState();
+      if (currentState != LocalNodeState.Active) {
+        swarmApi.swarmInit(new SwarmInitRequest("0.0.0.0:2377", "127.0.0.1", null, null, null, false, null, null));
+      }
+    }
+    catch (Exception ignored) {
+      //
+    }
+    return currentState;
+  }
+}

--- a/api-client/src/test/java/de/gesellix/docker/remote/api/testutil/TarUtil.java
+++ b/api-client/src/test/java/de/gesellix/docker/remote/api/testutil/TarUtil.java
@@ -1,0 +1,42 @@
+package de.gesellix.docker.remote.api.testutil;
+
+import okio.BufferedSink;
+import okio.Okio;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+
+public class TarUtil {
+
+  public File unTar(File tarFile) throws IOException {
+    File destDir = Files.createTempDirectory("de-gesellix-tests").toFile();
+    destDir.deleteOnExit();
+
+    TarArchiveInputStream tis = new TarArchiveInputStream(new FileInputStream(tarFile));
+    TarArchiveEntry tarEntry;
+    while ((tarEntry = tis.getNextTarEntry()) != null) {
+      File outputFile = new File(destDir, tarEntry.getName());
+      if (tarEntry.isDirectory()) {
+        if (!outputFile.exists()) {
+          outputFile.mkdirs();
+        }
+      }
+      else {
+        outputFile.getParentFile().mkdirs();
+        FileOutputStream fos = new FileOutputStream(outputFile);
+        BufferedSink sink = Okio.buffer(Okio.sink(fos));
+        sink.writeAll(Okio.buffer(Okio.source(tis)));
+        sink.flush();
+        sink.close();
+        fos.close();
+      }
+    }
+    tis.close();
+    return destDir;
+  }
+}

--- a/api-client/src/test/java/de/gesellix/docker/remote/api/testutil/TestImage.java
+++ b/api-client/src/test/java/de/gesellix/docker/remote/api/testutil/TestImage.java
@@ -1,0 +1,39 @@
+package de.gesellix.docker.remote.api.testutil;
+
+import de.gesellix.docker.remote.api.EngineApiClient;
+
+import java.util.Objects;
+
+public class TestImage {
+
+  private final EngineApiClient engineApiClient;
+  private final String repository;
+  private final String tag;
+
+  public TestImage(EngineApiClient engineApiClient) {
+    this.engineApiClient = engineApiClient;
+
+    boolean isWindows = Objects.requireNonNull(engineApiClient.getSystemApi().systemVersion().getOs()).equalsIgnoreCase("windows");
+    this.repository = "gesellix/echo-server";
+    this.tag = isWindows ? "os-windows" : "os-linux";
+
+    // TODO consider NOT calling prepare inside the constructor
+    prepare();
+  }
+
+  public void prepare() {
+    engineApiClient.getImageApi().imageCreate(getImageName(), null, null, getImageTag(), null, null, null, null, null);
+  }
+
+  public String getImageWithTag() {
+    return getImageName() + ":" + getImageTag();
+  }
+
+  public String getImageName() {
+    return repository;
+  }
+
+  public String getImageTag() {
+    return tag;
+  }
+}

--- a/api-client/src/test/resources/images/builder/Dockerfile
+++ b/api-client/src/test/resources/images/builder/Dockerfile
@@ -1,0 +1,3 @@
+FROM test:build-base
+LABEL de.gesellix.docker-client.test="1"
+COPY payload.txt /payload.txt

--- a/api-client/src/test/resources/images/builder/payload.txt
+++ b/api-client/src/test/resources/images/builder/payload.txt
@@ -1,0 +1,1 @@
+the wind caught it

--- a/api-client/src/test/resources/logback-test.xml
+++ b/api-client/src/test/resources/logback-test.xml
@@ -1,0 +1,16 @@
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="de.gesellix.docker.remote.api" level="DEBUG"/>
+  <!--  <logger name="de.gesellix.docker.engine" level="DEBUG"/>-->
+  <logger name="de.gesellix.docker.client.filesocket" level="INFO"/>
+
+  <root level="INFO">
+    <appender-ref ref="STDOUT"/>
+  </root>
+</configuration>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,8 @@ val dependencyVersions = listOf(
   "org.opentest4j:opentest4j:1.2.0"
 )
 
-val dependencyVersionsByGroup = mapOf<String, String>(
+val dependencyVersionsByGroup = mapOf(
+  "org.junit.platform" to "1.8.1"
 )
 
 subprojects {


### PR DESCRIPTION
Expected test failures on Windows:

> 79 tests completed, 2 failed, 5 skipped

- [ ] ContainerApiIntegrationTest. containerLogsWithTty()
- [ ] ContainerApiIntegrationTest. containerLogsWithoutTty()

---

Actual:
- [x] `Expected an int but was 8695802657 at path $[0].Size`
    -> https://github.com/docker-client/docker-remote-api/releases/tag/v2021-10-16T15-43-00
- [x] `cannot pause Windows Server Containers`
    -> https://github.com/gesellix/docker-client/blob/c7d8e20df61863a504919d9570e972a466096557/client/src/main/groovy/de/gesellix/docker/client/LocalDocker.groovy#L93
- [ ] several `WARNING: A connection to http://2f7661722f72756e2f646f636b65722e736f636b.socket/ was leaked. Did you forget to close a response body?`
    -> `To see where this was allocated, set the OkHttpClient logger level to FINE: Logger.getLogger(OkHttpClient.class.getName()).setLevel(Level.FINE);`