### PR TITLE
Fix Windows container test cases

### DIFF
--- a/api-client/src/test/java/de/gesellix/docker/remote/api/client/ContainerApiIntegrationTest.java
+++ b/api-client/src/test/java/de/gesellix/docker/remote/api/client/ContainerApiIntegrationTest.java
@@ -366,7 +366,7 @@ class ContainerApiIntegrationTest {
     containerApi.containerCreate(containerCreateRequest, "container-logs-test");
     containerApi.containerStart("container-logs-test", null);
 
-    Duration timeout = Duration.of(5, SECONDS);
+    Duration timeout = Duration.of(10, SECONDS);
     LogFrameStreamCallback callback = new LogFrameStreamCallback();
 
     new Thread(() -> containerApi.containerLogs(

--- a/api-client/src/test/java/de/gesellix/docker/remote/api/testutil/TestImage.java
+++ b/api-client/src/test/java/de/gesellix/docker/remote/api/testutil/TestImage.java
@@ -9,13 +9,14 @@ public class TestImage {
   private final EngineApiClient engineApiClient;
   private final String repository;
   private final String tag;
+  private final boolean useWindowsContainer;
 
   public TestImage(EngineApiClient engineApiClient) {
     this.engineApiClient = engineApiClient;
 
-    boolean isWindows = Objects.requireNonNull(engineApiClient.getSystemApi().systemVersion().getOs()).equalsIgnoreCase("windows");
+    this.useWindowsContainer = Objects.requireNonNull(engineApiClient.getSystemApi().systemVersion().getOs()).equalsIgnoreCase("windows");
     this.repository = "gesellix/echo-server";
-    this.tag = isWindows ? "os-windows" : "os-linux";
+    this.tag = useWindowsContainer ? "os-windows" : "os-linux";
 
     // TODO consider NOT calling prepare inside the constructor
     prepare();
@@ -35,5 +36,9 @@ public class TestImage {
 
   public String getImageTag() {
     return tag;
+  }
+
+  public boolean isWindowsContainer() {
+    return useWindowsContainer;
   }
 }


### PR DESCRIPTION
Works around "filesystem operations against a running Hyper-V container are not supported" errors.

Other fixes require updates to the Docker images, see https://github.com/gesellix/docker-client/issues/259
