### PR TITLE
Enforce commons-io:2.11.0, address CVE-2021-29425

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,6 +13,7 @@ plugins {
 }
 
 val dependencyVersions = listOf(
+  "commons-io:commons-io:2.11.0",
   "org.apiguardian:apiguardian-api:1.1.2",
   "org.jetbrains:annotations:23.0.0",
   "org.jetbrains.kotlin:kotlin-reflect:1.6.21",


### PR DESCRIPTION
This CVE only affects the test scope by commons-io being a transitive dependency of `io.kotlintest:kotlintest-runner-junit5:3.4.2`, yet we're playing safe here.

See https://nvd.nist.gov/vuln/detail/CVE-2021-29425
