### PR TITLE
Require okio >= 3.x

### DIFF
--- a/api-client/build.gradle.kts
+++ b/api-client/build.gradle.kts
@@ -24,10 +24,15 @@ dependencies {
         prefer("1.13.0")
       }
     }
-    implementation("com.squareup.okio:okio") {
-      version {
-        strictly("[2.5,4)")
-        prefer("3.1.0")
+    listOf(
+      "com.squareup.okio:okio",
+      "com.squareup.okio:okio-jvm"
+    ).forEach {
+      implementation(it) {
+        version {
+          strictly("[3,4)")
+          prefer("3.1.0")
+        }
       }
     }
     implementation("com.squareup.okhttp3:okhttp") {


### PR DESCRIPTION
Explicitly using okio-jvm makes the artifacts Maven-compatible.

Relates to https://github.com/gesellix/docker-client/issues/245