### PR TITLE
Accept the "application/vnd.docker.multiplexed-stream" response header as of api v1.42

### DIFF
--- a/api-client/src/main/kotlin/de/gesellix/docker/remote/api/core/ResponseConsumer.kt
+++ b/api-client/src/main/kotlin/de/gesellix/docker/remote/api/core/ResponseConsumer.kt
@@ -62,6 +62,9 @@ inline fun ResponseBody?.consumeFrames(mediaType: String?, expectMultiplexedResp
     return emptyFlow()
   }
   when (mediaType) {
+    // TODO since api v1.42 we should be able to use the media-type instead of the 'expectMultiplexedResponse' flag
+    // see https://docs.docker.com/engine/api/version-history/#v142-api-changes
+    "application/vnd.docker.multiplexed-stream",
     "application/vnd.docker.raw-stream" -> {
       val reader = FrameReader(source(), expectMultiplexedResponse)
       val events = flow {


### PR DESCRIPTION
This is available since api v1.42, see https://docs.docker.com/engine/api/version-history/#v142-api-changes
