### PR TITLE
Bump kotest, includes migration to the new artifact name

### DIFF
--- a/api-client/build.gradle.kts
+++ b/api-client/build.gradle.kts
@@ -76,7 +76,7 @@ dependencies {
   implementation("org.slf4j:slf4j-api:2.0.11")
   testImplementation("ch.qos.logback:logback-classic:[1.2,2)!!1.3.14")
 
-  testImplementation("io.kotlintest:kotlintest-runner-junit5:3.4.2")
+  testImplementation("io.kotest:kotest-runner-junit5-jvm:5.7.2")
   testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.1")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.1")
   testRuntimeOnly("cglib:cglib-nodep:3.3.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,9 @@ val dependencyVersions = listOf(
   "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.22",
   "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3",
   "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.7.3",
+  "org.jetbrains.kotlinx:kotlinx-coroutines-debug:1.7.3",
+  "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.7.3",
+  "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3",
   "org.junit:junit-bom:5.10.1",
   "org.junit.jupiter:junit-jupiter-api:5.10.1",
   "org.opentest4j:opentest4j:1.3.0"


### PR DESCRIPTION
io.kotlintest:kotlintest-runner-junit5:3.4.2
 -> io.kotest:kotest-runner-junit5-jvm:5.7.2